### PR TITLE
Read batch run commands from the config file

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -16,6 +16,7 @@ Pygments==2.2.0
 pyparsing==2.1.10
 pytest==3.0.5
 pytest-mock==1.5.0
+PyYAML==3.13
 requests==2.12.5
 simplegeneric==0.8.1
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,25 @@
-appdirs>=1.4.0
+appdirs==1.4.3
 autorepr==0.3.0
 click==6.7
 -e git+https://github.com/alces-software/click-repl.git@6a809b2af43054035027618f9fd37af4c31a8abc#egg=click_repl
+decorator==4.0.11
+ipython==5.3.0
+ipython-genutils==0.1.0
 packaging==16.8
+pexpect==4.2.1
+pickleshare==0.7.4
+plumbum==1.6.7
 prompt-toolkit==1.0.9
+ptyprocess==0.5.1
+py==1.4.32
+Pygments==2.2.0
 pyparsing==2.1.10
+pytest==3.0.5
+pytest-mock==1.5.0
+PyYAML==3.13
 requests==2.12.5
+simplegeneric==0.8.1
 six==1.10.0
 terminaltables==3.1.0
+traitlets==4.3.2
 wcwidth==0.1.7

--- a/src/action.py
+++ b/src/action.py
@@ -16,7 +16,7 @@ class Action:
 
     def create(self, click_group):
         def action_func(self=self):
-            print(self.name())
+            print(self.command())
         action_func.__name__ = self.__name__()
         action_func = self.__click_command(action_func, click_group)
 
@@ -27,6 +27,12 @@ class Action:
         default = 'MISSING: Help for {}'.format(self.__name__())
         self.data.setdefault('help', default)
         return self.data['help']
+
+    def command(self):
+        n = self.__name__()
+        default = 'echo "No command given for: {}" >&2'.format(n)
+        self.data.setdefault('command', default)
+        return self.data['command']
 
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)

--- a/src/action.py
+++ b/src/action.py
@@ -17,8 +17,7 @@ class Action:
 
     def create(self, click_group):
         def action_func(ctx, self=self):
-            print(ctx.obj)
-            print(self.command())
+            return self.run_command(ctx)
         action_func.__name__ = self.__name__()
         action_func = click.pass_context(action_func)
         action_func = self.__click_command(action_func, click_group)
@@ -36,6 +35,10 @@ class Action:
         default = 'echo "No command given for: {}" >&2'.format(n)
         self.data.setdefault('command', default)
         return self.data['command']
+
+    def run_command(self, ctx):
+        print(ctx.obj)
+        print(self.command())
 
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)

--- a/src/action.py
+++ b/src/action.py
@@ -6,7 +6,10 @@ import yaml
 class Action:
     def __init__(self, path):
         self.path = path
-        self.data = yaml.load(path)
+        def __read_data():
+            with open(self.path, 'r') as stream:
+                return yaml.load(stream) or {}
+        self.data = __read_data()
 
     def __name__(self):
         return os.path.basename(os.path.dirname(self.path))
@@ -18,7 +21,12 @@ class Action:
         action_func = self.__click_command(action_func, click_group)
 
     def __click_command(self, func, click_group):
-        return click_group.command(help='TODO')(func)
+        return click_group.command(help=self.help())(func)
+
+    def help(self):
+        default = 'MISSING: Help for {}'.format(self.__name__())
+        self.data.setdefault('help', default)
+        return self.data['help']
 
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)

--- a/src/action.py
+++ b/src/action.py
@@ -13,9 +13,9 @@ class Action:
         def action_func(self=self):
             print(self.name())
         action_func.__name__ = self.__name__()
-        action_func = self.__click_func(action_func, click_group)
+        action_func = self.__click_command(action_func, click_group)
 
-    def __click_func(self, func, click_group):
+    def __click_command(self, func, click_group):
         return click_group.command(help='TODO')(func)
 
 def add_actions(click_group, namespace):

--- a/src/action.py
+++ b/src/action.py
@@ -9,16 +9,21 @@ class Action:
     def name(self):
         return os.path.basename(os.path.dirname(self.path))
 
+    def create(self, click_group):
+        def action_func(self=self):
+            print(self.name())
+        action_func.__name__ = self.name()
+        action_func = self.__click_func(action_func, click_group)
+
+    # This method must be called after `create` to ensure the local
+    # function has been defined
+    def __click_func(self, func, click_group):
+        return click_group.command(help='TODO')(func)
 
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)
     for action in actions:
-        def _temp_f(action=action):
-            print(action)
-        _temp_f.__name__ = action.name()
-        locals()[action] = _temp_f
-        del _temp_f
-        locals()[action] = click_group.command(help='TODO')(locals()[action])
+        action.create(click_group)
 
 def __glob_actions(namespace):
     parts = ['/var/lib/adminware/tools', namespace, '*/config.yaml']

--- a/src/action.py
+++ b/src/action.py
@@ -5,7 +5,7 @@ import os
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)
     for action in sorted(actions):
-        def _temp_f():
+        def _temp_f(action=action):
             print(action)
         _temp_f.__name__ = action
         locals()[action] = _temp_f

--- a/src/action.py
+++ b/src/action.py
@@ -1,0 +1,22 @@
+
+import glob
+import os
+
+def add_actions(click_group, namespace):
+    actions = __glob_actions(namespace)
+    for action in sorted(actions):
+        def _temp_f():
+            print(action)
+        _temp_f.__name__ = action
+        locals()[action] = _temp_f
+        del _temp_f
+        locals()[action] = click_group.command(help='TODO')(locals()[action])
+
+
+def __glob_actions(namespace):
+    parts = ['/var/lib/adminware/tools', namespace, '*/config.yaml']
+    paths = glob.glob(os.path.join(*parts))
+    return dict(
+        ((os.path.basename(os.path.dirname(p)), p) for p in paths)
+    )
+

--- a/src/action.py
+++ b/src/action.py
@@ -6,13 +6,13 @@ class Action:
     def __init__(self, path):
         self.path = path
 
-    def name(self):
+    def __name__(self):
         return os.path.basename(os.path.dirname(self.path))
 
     def create(self, click_group):
         def action_func(self=self):
             print(self.name())
-        action_func.__name__ = self.name()
+        action_func.__name__ = self.__name__()
         action_func = self.__click_func(action_func, click_group)
 
     # This method must be called after `create` to ensure the local

--- a/src/action.py
+++ b/src/action.py
@@ -1,10 +1,12 @@
 
 import glob
 import os
+import yaml
 
 class Action:
     def __init__(self, path):
         self.path = path
+        self.data = yaml.load(path)
 
     def __name__(self):
         return os.path.basename(os.path.dirname(self.path))

--- a/src/action.py
+++ b/src/action.py
@@ -2,21 +2,26 @@
 import glob
 import os
 
+class Action:
+    def __init__(self, path):
+        self.path = path
+
+    def name(self):
+        return os.path.basename(os.path.dirname(self.path))
+
+
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)
-    for action in sorted(actions):
+    for action in actions:
         def _temp_f(action=action):
             print(action)
-        _temp_f.__name__ = action
+        _temp_f.__name__ = action.name()
         locals()[action] = _temp_f
         del _temp_f
         locals()[action] = click_group.command(help='TODO')(locals()[action])
 
-
 def __glob_actions(namespace):
     parts = ['/var/lib/adminware/tools', namespace, '*/config.yaml']
     paths = glob.glob(os.path.join(*parts))
-    return dict(
-        ((os.path.basename(os.path.dirname(p)), p) for p in paths)
-    )
+    return list(map(lambda x: Action(x), paths))
 

--- a/src/action.py
+++ b/src/action.py
@@ -2,6 +2,7 @@
 import glob
 import os
 import yaml
+import click
 
 class Action:
     def __init__(self, path):
@@ -15,9 +16,11 @@ class Action:
         return os.path.basename(os.path.dirname(self.path))
 
     def create(self, click_group):
-        def action_func(self=self):
+        def action_func(ctx, self=self):
+            print(ctx.obj)
             print(self.command())
         action_func.__name__ = self.__name__()
+        action_func = click.pass_context(action_func)
         action_func = self.__click_command(action_func, click_group)
 
     def __click_command(self, func, click_group):

--- a/src/action.py
+++ b/src/action.py
@@ -15,8 +15,6 @@ class Action:
         action_func.__name__ = self.__name__()
         action_func = self.__click_func(action_func, click_group)
 
-    # This method must be called after `create` to ensure the local
-    # function has been defined
     def __click_func(self, func, click_group):
         return click_group.command(help='TODO')(func)
 

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -1,6 +1,7 @@
 
 import click
 import action
+import groups
 
 def add_commands(appliance):
 
@@ -28,6 +29,8 @@ def add_commands(appliance):
     def run(ctx, **kwargs):
         obj = { 'nodes' : [] }
         if kwargs['node']: obj['nodes'].append(kwargs['node'])
+        if kwargs['group']:
+            obj['nodes'].extend(groups.nodes_in(kwargs['group']))
         ctx.obj = { 'adminware' : obj }
         pass
     action.add_actions(run, 'batch')

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -1,6 +1,6 @@
 
 import click
-
+import action
 
 def add_commands(appliance):
 
@@ -28,3 +28,5 @@ def add_commands(appliance):
         # XXX Add dynamic subcommands pulled from
         # `/var/lib/adminware/tools/batch/` to this group
         pass
+    action.add_actions(run, 'batch')
+

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -24,7 +24,7 @@ def add_commands(appliance):
     @batch.group(help='TODO')
     @click.option('--node', '-n')
     @click.option('--group', '-g')
-    def run():
+    def run(**kwargs):
         # XXX Add dynamic subcommands pulled from
         # `/var/lib/adminware/tools/batch/` to this group
         pass

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -26,10 +26,9 @@ def add_commands(appliance):
     @click.option('--group', '-g')
     @click.pass_context
     def run(ctx, **kwargs):
-        ctx.obj = {}
-        ctx.obj['test'] = 'test'
-        # XXX Add dynamic subcommands pulled from
-        # `/var/lib/adminware/tools/batch/` to this group
+        obj = { 'nodes' : [] }
+        if kwargs['node']: obj['nodes'].append(kwargs['node'])
+        ctx.obj = { 'adminware' : obj }
         pass
     action.add_actions(run, 'batch')
 

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -24,7 +24,10 @@ def add_commands(appliance):
     @batch.group(help='TODO')
     @click.option('--node', '-n')
     @click.option('--group', '-g')
-    def run(**kwargs):
+    @click.pass_context
+    def run(ctx, **kwargs):
+        ctx.obj = {}
+        ctx.obj['test'] = 'test'
         # XXX Add dynamic subcommands pulled from
         # `/var/lib/adminware/tools/batch/` to this group
         pass


### PR DESCRIPTION
This PR partly implements #21. I will read the config files from under `/v/l/a/tools/batch` and add them to the CLI. This required some funky python meta-programming to set the command names correctly. Also all the `click` decorators add to be applied manually.

It does not run the commands at this point. It only reads the config file and outputs the command it would run to the screen. Currently it does not support multiple subnamespaces. These will be added at a latter date.