### PR TITLE
Implement running commands on a remote host

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -33,7 +33,7 @@ class Action:
 
     def command(self):
         n = self.__name__()
-        default = 'echo "No command given for: {}" >&2'.format(n)
+        default = 'echo "No command given for: {}"'.format(n)
         self.data.setdefault('command', default)
         return self.data['command']
 

--- a/src/action.py
+++ b/src/action.py
@@ -3,6 +3,7 @@ import glob
 import os
 import yaml
 import click
+from plumbum import SshMachine
 
 class Action:
     def __init__(self, path):
@@ -37,8 +38,14 @@ class Action:
         return self.data['command']
 
     def run_command(self, ctx):
-        print(ctx.obj)
-        print(self.command())
+        for node in ctx.obj['adminware']['nodes']:
+            remote = SshMachine(node)
+            result = self.__run_remote_command(remote)
+            remote.close()
+            return result
+
+    def __run_remote_command(self, remote):
+        print(remote.cwd)
 
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)

--- a/src/action.py
+++ b/src/action.py
@@ -45,7 +45,10 @@ class Action:
             return result
 
     def __run_remote_command(self, remote):
-        print(remote.cwd)
+        echo = remote['echo']
+        bash = remote['bash']
+        cmd = echo[self.command()] | bash
+        print(cmd())
 
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)

--- a/src/action.py
+++ b/src/action.py
@@ -42,7 +42,6 @@ class Action:
             remote = plumbum.machines.SshMachine(node)
             result = self.__run_remote_command(remote)
             remote.close()
-            return result
 
     def __run_remote_command(self, remote):
         def __mktemp_d():

--- a/src/action.py
+++ b/src/action.py
@@ -45,10 +45,25 @@ class Action:
             return result
 
     def __run_remote_command(self, remote):
-        echo = remote['echo']
-        bash = remote['bash']
-        cmd = echo[self.command()] | bash
-        print(cmd())
+        def __mktemp_d():
+            mktemp = remote['mktemp']
+            return mktemp('-d').rstrip()
+
+        def __run_cmd():
+            echo = remote['echo']
+            bash = remote['bash']
+            cmd = echo[self.command()] | bash
+            return cmd().rstrip()
+
+        def __rm_rf(path):
+            remote['rm']['-rf'](path)
+
+        try:
+            temp_dir = __mktemp_d()
+            with remote.cwd(remote.cwd / temp_dir):
+                print(__run_cmd())
+        finally:
+            __rm_rf(temp_dir)
 
 def add_actions(click_group, namespace):
     actions = __glob_actions(namespace)


### PR DESCRIPTION
This mostly implements #22. It uses the `plumbum` library to ssh onto the remote machine and run the command stored withing `config.yaml`. Before doing this however, it `scp` the entire command directory (containing `config.yaml`) to the remote machine. This allows the command to run a script contained within it.

ATM it dumps the result to the screen. The original issue mentions outputting it into a table OR hide successful commands. This still needs to be implemented.