### PR TITLE
Improve error handling and store the stderr

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -29,7 +29,12 @@ class Action:
             for node in ctx.obj['adminware']['nodes']:
                 job = Job(node = node, batch = self.batch)
                 session.add(job)
-                print(job.run())
+                job.run()
+                if job.exit_code == 0:
+                    symbol = 'Pass'
+                else:
+                    symbol = 'Failed: {}'.format(job.exit_code)
+                print("{}: {}".format(job.node, symbol))
         finally:
             session.commit()
             session.close()

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -56,7 +56,6 @@ class Job(Base):
         finally:
             __rm_rf(temp_dir)
             remote.close()
-        return self.stdout
 
     def __remote(self):
         return plumbum.machines.SshMachine(self.node)

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -25,40 +25,50 @@ class Job(Base):
     batch = relationship("Batch", backref="jobs")
 
     def run(self):
-        def __mktemp_d():
+        def __with_remote(func):
+            def wrapper(*args, **kwargs):
+                try:
+                    remote = plumbum.machines.SshMachine(self.node)
+                    func(remote, *args, **kwargs)
+                except:
+                    pass
+            return wrapper
+
+        def __mktemp_d(remote):
             mktemp = remote['mktemp']
             return mktemp('-d').rstrip()
 
-        def __copy_files(dst):
+        def __copy_files(remote, dst):
             parts = [os.path.dirname(self.batch.config), '*']
             for src_path in glob.glob(os.path.join(*parts)):
                 src = plumbum.local.path(src_path)
                 plumbum.path.utils.copy(src, dst)
 
-        def __run_cmd():
+        def __run_cmd(remote):
             echo = remote['echo']
             bash = remote['bash']
             cmd = echo[self.batch.command()] | bash
             return cmd.run()
 
-        def __rm_rf(path):
+        def __rm_rf(remote, path):
             remote['rm']['-rf'](path)
 
-        remote = self.__remote()
-        try:
-            temp_dir = __mktemp_d()
-            __copy_files(remote.path(temp_dir))
-            with remote.cwd(remote.cwd / temp_dir):
-                results = __run_cmd()
-                self.exit_code = results[0]
-                self.stdout = results[1]
-                self.stderr = results[2]
-        finally:
-            __rm_rf(temp_dir)
-            remote.close()
-
-    def __remote(self):
-        return plumbum.machines.SshMachine(self.node)
+        @__with_remote
+        def __run(remote):
+            try:
+                temp_dir = __mktemp_d(remote)
+                __copy_files(remote, remote.path(temp_dir))
+                with remote.cwd(remote.cwd / temp_dir):
+                    results = __run_cmd(remote)
+                    self.exit_code = results[0]
+                    self.stdout = results[1]
+                    self.stderr = results[2]
+            except Exception as err:
+                print(err)
+            finally:
+                __rm_rf(temp_dir)
+                remote.close()
+        __run()
 
     def __init__(self, **kwargs):
         self.node = kwargs['node']


### PR DESCRIPTION
This PR updates the error handling concerning failed commands and ssh connections. This should stop it from aborting early with no error if the `ssh` fails.

It also updates the db entry for `Job` to store the `stderr` and exit code of the commands. Fixes #32 