### PR TITLE
Implement the command for displaying the batch history

### DIFF
--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -1,0 +1,9 @@
+
+import groups
+
+def set_nodes_context(ctx, **kwargs):
+    obj = { 'nodes' : [] }
+    if kwargs['node']: obj['nodes'].append(kwargs['node'])
+    if kwargs['group']:
+        obj['nodes'].extend(groups.nodes_in(kwargs['group']))
+    ctx.obj = { 'adminware' : obj }

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -30,6 +30,7 @@ def add_commands(appliance):
                 return False
             return True if job.node in nodes else False
         jobs = [job for job in jobs if job_filter(job)]
+        jobs = sorted(jobs, key=lambda job: job.created_date, reverse=True)
         def table_rows():
             rows = [['Batch', 'Node', 'Command', 'Exit Code', 'Date']]
             for job in jobs:

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -21,8 +21,12 @@ def add_commands(appliance):
     @click.pass_context
     def history(ctx, **options):
         set_nodes_context(ctx, **options)
+        nodes = ctx.obj['adminware']['nodes']
         session = Session()
         jobs = session.query(Job).all()
+        def job_filter(job):
+            return True if job.node in nodes else False
+        jobs = [job for job in jobs if job_filter(job)]
         def table_rows():
             rows = [['Batch', 'Node', 'Command', 'Exit Code', 'Date']]
             for job in jobs:

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -3,6 +3,9 @@ import click
 import action
 import groups
 
+from database import Session
+from models.batch import Batch
+
 def add_commands(appliance):
 
     @appliance.group(help='TODO')
@@ -14,7 +17,8 @@ def add_commands(appliance):
     @click.option('--group', '-g')
     @click.option('--job-id', '-j')
     def history(**options):
-        pass
+        session = Session()
+        print(session.query(Batch).all())
 
     @batch.command(help='TODO')
     @click.argument('job_id')

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -6,7 +6,7 @@ from terminaltables import AsciiTable
 
 from cli_utils import set_nodes_context
 from database import Session
-from models.batch import Batch
+from models.job import Job
 
 def add_commands(appliance):
 
@@ -22,10 +22,11 @@ def add_commands(appliance):
     def history(ctx, **options):
         set_nodes_context(ctx, **options)
         session = Session()
-        batches = session.query(Batch).all()
+        jobs = session.query(Job).all()
         def table_rows():
             rows = [['Batch', 'Command', 'Date']]
-            for batch in batches:
+            for job in jobs:
+                batch = job.batch
                 row = [batch.id, batch.__name__(), batch.created_date]
                 rows.append(row)
             return rows

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -2,6 +2,7 @@
 import click
 import action
 import groups
+from terminaltables import AsciiTable
 
 from cli_utils import set_nodes_context
 from database import Session
@@ -22,7 +23,13 @@ def add_commands(appliance):
         set_nodes_context(ctx, **options)
         session = Session()
         batches = session.query(Batch).all()
-        print(batches)
+        def table_rows():
+            rows = [['Batch', 'Command', 'Date']]
+            for batch in batches:
+                row = [batch.id, batch.__name__(), batch.created_date]
+                rows.append(row)
+            return rows
+        print(AsciiTable(table_rows()).table)
 
     @batch.command(help='TODO')
     @click.argument('job_id')

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -24,10 +24,14 @@ def add_commands(appliance):
         session = Session()
         jobs = session.query(Job).all()
         def table_rows():
-            rows = [['Batch', 'Command', 'Date']]
+            rows = [['Batch', 'Node', 'Command', 'Exit Code', 'Date']]
             for job in jobs:
                 batch = job.batch
-                row = [batch.id, batch.__name__(), batch.created_date]
+                row = [batch.id,
+                       job.node,
+                       batch.__name__(),
+                       job.exit_code,
+                       batch.created_date]
                 rows.append(row)
             return rows
         print(AsciiTable(table_rows()).table)

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -22,9 +22,12 @@ def add_commands(appliance):
     def history(ctx, **options):
         set_nodes_context(ctx, **options)
         nodes = ctx.obj['adminware']['nodes']
+        batch_id_filter = options['job_id']
         session = Session()
         jobs = session.query(Job).all()
         def job_filter(job):
+            if batch_id_filter and int(batch_id_filter) != job.batch.id:
+                return False
             return True if job.node in nodes else False
         jobs = [job for job in jobs if job_filter(job)]
         def table_rows():

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -17,9 +17,12 @@ def add_commands(appliance):
     @click.option('--node', '-n')
     @click.option('--group', '-g')
     @click.option('--job-id', '-j')
-    def history(**options):
+    @click.pass_context
+    def history(ctx, **options):
+        set_nodes_context(ctx, **options)
         session = Session()
-        print(session.query(Batch).all())
+        batches = session.query(Batch).all()
+        print(batches)
 
     @batch.command(help='TODO')
     @click.argument('job_id')

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -3,6 +3,7 @@ import click
 import action
 import groups
 
+from cli_utils import set_nodes_context
 from database import Session
 from models.batch import Batch
 
@@ -31,11 +32,6 @@ def add_commands(appliance):
     @click.option('--group', '-g')
     @click.pass_context
     def run(ctx, **kwargs):
-        obj = { 'nodes' : [] }
-        if kwargs['node']: obj['nodes'].append(kwargs['node'])
-        if kwargs['group']:
-            obj['nodes'].extend(groups.nodes_in(kwargs['group']))
-        ctx.obj = { 'adminware' : obj }
-        pass
+        set_nodes_context(ctx, **kwargs)
     action.add_actions(run, 'batch')
 

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -17,12 +17,12 @@ def add_commands(appliance):
     @batch.command(help='TODO')
     @click.option('--node', '-n')
     @click.option('--group', '-g')
-    @click.option('--job-id', '-j')
+    @click.option('--batch-id', '-i')
     @click.pass_context
     def history(ctx, **options):
         set_nodes_context(ctx, **options)
         nodes = ctx.obj['adminware']['nodes']
-        batch_id_filter = options['job_id']
+        batch_id_filter = options['batch_id']
         session = Session()
         jobs = session.query(Job).all()
         def job_filter(job):


### PR DESCRIPTION
This PR implements the `batch history` command and fixes #25. It polls the database and displays each job on a new line per node. NOTE: The `id` is the `Batch.id` and will be repeated if it was ran on multiple nodes.

It will filter the results using `--node` and `--group`. It will also filter on `--batch-id` if given. NOTE: Currently all the `Job` models are loaded into memory and then filtered. This should be fixed using SQL. See #37 