### PR TITLE
Implement `batch view` and tweak the SQL

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -26,6 +26,8 @@ class Action:
         session = Session()
         try:
             session.add(self.batch)
+            session.commit() # Saves the batch to receive and id
+            print("Batch: {}".format(self.batch.id))
             for node in ctx.obj['adminware']['nodes']:
                 job = Job(node = node, batch = self.batch)
                 session.add(job)

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -55,11 +55,14 @@ def add_commands(appliance):
                      .filter(Job.node == node) \
                      .join(Job, Batch.jobs) \
                      .first()
-        print("Exit Code: {}".format(job.exit_code))
-        print("STDOUT:")
-        print(job.stdout)
-        print("STDERR:")
-        print(job.stderr)
+        table_data = [
+            ['Exit Code', job.exit_code],
+            ['STDOUT', job.stdout],
+            ['STDERR', job.stderr]
+        ]
+        table = AsciiTable(table_data)
+        table.inner_row_border = True
+        print(table.table)
 
     @batch.group(help='TODO')
     @click.option('--node', '-n')

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -6,7 +6,9 @@ from terminaltables import AsciiTable
 
 from cli_utils import set_nodes_context
 from database import Session
+
 from models.job import Job
+from models.batch import Batch
 
 def add_commands(appliance):
 
@@ -48,7 +50,16 @@ def add_commands(appliance):
     @click.argument('batch_id')
     @click.argument('node')
     def view(batch_id, node):
-        pass
+        session = Session()
+        job = session.query(Job) \
+                     .filter(Job.node == node) \
+                     .join(Job, Batch.jobs) \
+                     .first()
+        print("Exit Code: {}".format(job.exit_code))
+        print("STDOUT:")
+        print(job.stdout)
+        print("STDERR:")
+        print(job.stderr)
 
     @batch.group(help='TODO')
     @click.option('--node', '-n')

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -26,11 +26,13 @@ def add_commands(appliance):
         nodes = ctx.obj['adminware']['nodes']
         batch_id_filter = options['batch_id']
         session = Session()
-        jobs = session.query(Job).all()
+        jobs = session.query(Job) \
+                      .filter(Job.node.in_(nodes)) \
+                      .all()
         def job_filter(job):
             if batch_id_filter and int(batch_id_filter) != job.batch.id:
                 return False
-            return True if job.node in nodes else False
+            return True
         jobs = [job for job in jobs if job_filter(job)]
         jobs = sorted(jobs, key=lambda job: job.created_date, reverse=True)
         def table_rows():

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -54,7 +54,11 @@ def add_commands(appliance):
         job = session.query(Job) \
                      .filter(Job.node == node) \
                      .join(Job, Batch.jobs) \
+                     .filter(Batch.id == int(batch_id)) \
                      .first()
+        if job == None:
+            click.echo('No job found', err=True)
+            exit(1)
         table_data = [
             ['Date', job.created_date],
             ['Batch', job.batch.id],

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -45,9 +45,9 @@ def add_commands(appliance):
         print(AsciiTable(table_rows()).table)
 
     @batch.command(help='TODO')
-    @click.argument('job_id')
+    @click.argument('batch_id')
     @click.argument('node')
-    def view(job_id, node):
+    def view(batch_id, node):
         pass
 
     @batch.group(help='TODO')

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -56,6 +56,10 @@ def add_commands(appliance):
                      .join(Job, Batch.jobs) \
                      .first()
         table_data = [
+            ['Date', job.created_date],
+            ['Batch', job.batch.id],
+            ['Node', job.node],
+            ['Command', job.batch.__name__()],
             ['Exit Code', job.exit_code],
             ['STDOUT', job.stdout],
             ['STDERR', job.stderr]

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -26,14 +26,12 @@ def add_commands(appliance):
         nodes = ctx.obj['adminware']['nodes']
         batch_id_filter = options['batch_id']
         session = Session()
-        jobs = session.query(Job) \
-                      .filter(Job.node.in_(nodes)) \
-                      .all()
-        def job_filter(job):
-            if batch_id_filter and int(batch_id_filter) != job.batch.id:
-                return False
-            return True
-        jobs = [job for job in jobs if job_filter(job)]
+        query = session.query(Job) \
+                       .filter(Job.node.in_(nodes))
+        if options['batch_id']:
+            query = query.join(Job, Batch.jobs) \
+                         .filter(Batch.id == int(options['batch_id']))
+        jobs = query.all()
         jobs = sorted(jobs, key=lambda job: job.created_date, reverse=True)
         def table_rows():
             rows = [['Batch', 'Node', 'Command', 'Exit Code', 'Date']]


### PR DESCRIPTION
This PR implements the `batch view` command, fixes #26. It preforms a db query that filters the jobs by node and batch before outputting the result.

At the same time, the filtering in the `history` command has also been updated to use SQL queries. This fixes #37.

Finally, `batch run` has been updated to output the `Batch.id`. This is so the user can then immediately use the `batch view` without looking up the batch number