### PR TITLE
Refactor how `Action` works in preparation for the `open` command

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -27,12 +27,9 @@ class Action:
         self.batch = Batch(config = self.path)
 
     def create(self, click_group, command_func):
-        def action_func(ctx):
-            if not ctx.obj['adminware']: ctx.obj['adminware'] = {}
-            ctx.obj['adminware']['batch'] = self.batch
-            return command_func(ctx)
+        def action_func():
+            return command_func(self.batch)
         action_func.__name__ = self.batch.__name__()
-        action_func = click.pass_context(action_func)
         action_func = self.__click_command(action_func, click_group)
 
     def __click_command(self, func, click_group):

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -80,8 +80,8 @@ def add_commands(appliance):
         set_nodes_context(ctx, **kwargs)
 
     @ClickGlob.command(run, 'batch')
-    def run_batch(ctx):
-        batch = ctx.obj['adminware']['batch']
+    @click.pass_context
+    def run_batch(ctx, batch):
         session = Session()
         try:
             session.add(batch)


### PR DESCRIPTION
The `Batch` command and `Action` class where highly coupled due to how they where originally implemented. This PR reduces the coupling by introducing a new `ClickGlob.command` decorator.

This decorator lives in the `action` module and is responsible for generating click commands from `/v/l/a/tools` directories. It requires the `click_group` solely for making the command. It no longer modifies the click context which is no longer passed into it.

The `Batch` module is now solely responsible for the `click.context` and needs to be passed explicitly.
It also receives a `batch` object which contains the command to be ran. It is up to `Batch` to connect to the database and running the job on all the nodes.