### PR TITLE
Create the base structure of `open` command

### DIFF
--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -17,6 +17,7 @@ def add_commands(appliance):
     open_command = appliance.group(help='TODO')(open_command)
 
     @ClickGlob.command(open_command, 'open')
-    def run_open(batch):
+    @click.pass_context
+    def run_open(ctx, batch):
         pass
 

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -1,5 +1,6 @@
 
 import click
+from action import ClickGlob
 
 # Note: this module cannot be called `open`, which would be consistent with
 # other command modules, as this conflicts with Python's built-in `open`
@@ -8,9 +9,14 @@ import click
 
 def add_commands(appliance):
 
-    @appliance.group(help='TODO')
     @click.option('--node', '-n', required=True)
-    def open():
-        # XXX Add dynamic subcommands pulled from
-        # `/var/lib/adminware/tools/open/` to this group
+    def open_command(**kwargs):
+        ctx.obj = { 'adminware' : { 'node' : kwargs['node'] } }
+
+    open_command.__name__ = 'open'
+    open_command = appliance.group(help='TODO')(open_command)
+
+    @ClickGlob.command(open_command, 'open')
+    def run_open(batch):
         pass
+

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -1,6 +1,7 @@
 
 import click
 from action import ClickGlob
+from models.job import Job
 
 # Note: this module cannot be called `open`, which would be consistent with
 # other command modules, as this conflicts with Python's built-in `open`
@@ -10,7 +11,8 @@ from action import ClickGlob
 def add_commands(appliance):
 
     @click.option('--node', '-n', required=True)
-    def open_command(**kwargs):
+    @click.pass_context
+    def open_command(ctx, **kwargs):
         ctx.obj = { 'adminware' : { 'node' : kwargs['node'] } }
 
     open_command.__name__ = 'open'
@@ -19,5 +21,6 @@ def add_commands(appliance):
     @ClickGlob.command(open_command, 'open')
     @click.pass_context
     def run_open(ctx, batch):
-        pass
+        job = Job(node = ctx.obj['adminware']['node'], batch = batch)
+        print(job.batch.command())
 


### PR DESCRIPTION
These few commits update the `open` command to pull its subcommands from `/v/l/a/tools/open`. It uses the same `Action` to add the commands as `batch run`.

Fixes #27 