### PR TITLE
Run the open jobs in interactive mode

### DIFF
--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -22,5 +22,5 @@ def add_commands(appliance):
     @click.pass_context
     def run_open(ctx, batch):
         job = Job(node = ctx.obj['adminware']['node'], batch = batch)
-        print(job.batch.command())
+        job.run(interactive = True)
 

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -26,6 +26,7 @@ class Job(Base):
     batch_id = Column(Integer, ForeignKey('batches.id'))
     batch = relationship("Batch", backref="jobs")
 
+
     def run(self, interactive=False):
         def __with_connection(func):
             def wrapper():

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -74,11 +74,11 @@ class Job(Base):
 
                 # Runs the command
                 with connection.cd(temp_dir):
-                    kwargs = {}
+                    kwargs = { 'warn' : True }
                     if interactive:
-                        kwargs = { 'pty': True }
+                        kwargs.update({ 'pty': True })
                     else:
-                        kwargs = { 'hide': 'both' }
+                        kwargs.update({ 'hide': 'both' })
                     cmd = self.batch.command()
                     result = connection.run(cmd, **kwargs)
                     __set_result(result)

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -26,7 +26,7 @@ class Job(Base):
     batch_id = Column(Integer, ForeignKey('batches.id'))
     batch = relationship("Batch", backref="jobs")
 
-    def run(self):
+    def run(self, interactive=False):
         def __with_connection(func):
             def wrapper():
                 connection = Connection(self.node)
@@ -74,7 +74,13 @@ class Job(Base):
 
                 # Runs the command
                 with connection.cd(temp_dir):
-                    result = connection.run(self.batch.command(), hide='both')
+                    kwargs = {}
+                    if interactive:
+                        kwargs = { 'pty': True }
+                    else:
+                        kwargs = { 'hide': 'both' }
+                    cmd = self.batch.command()
+                    result = connection.run(cmd, **kwargs)
                     __set_result(result)
             __run_command()
         __runner()


### PR DESCRIPTION
Now that `fabric` has replaced `plumbum`, it is a simple case of running the command with `pty`. The `run` parameters are slightly different between `interactive` and normal mode and concern the redirection of `stdout`/ `stderr`.

Fixes #28 