### PR TITLE
Create the `batch list` command

### DIFF
--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -47,12 +47,13 @@ def add_commands(appliance):
         print(AsciiTable(table_rows()).table)
 
     @batch.command(help='TODO')
-    def list():
+    @click.option('--number', '-n', default=10, type=int)
+    def list(number):
         session = Session()
         try:
             query = session.query(Batch) \
                            .order_by(Batch.created_date.desc()) \
-                           .limit(10)
+                           .limit(number)
             for batch in query.all():
                 print(batch.id)
 

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -47,6 +47,19 @@ def add_commands(appliance):
         print(AsciiTable(table_rows()).table)
 
     @batch.command(help='TODO')
+    def list():
+        session = Session()
+        try:
+            query = session.query(Batch) \
+                           .order_by(Batch.created_date.desc()) \
+                           .limit(10)
+            for batch in query.all():
+                print(batch.id)
+
+        finally:
+            session.close()
+
+    @batch.command(help='TODO')
     @click.argument('batch_id')
     @click.argument('node')
     def view(batch_id, node):

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -54,10 +54,13 @@ def add_commands(appliance):
             query = session.query(Batch) \
                            .order_by(Batch.created_date.desc()) \
                            .limit(number)
-            rows = [['Batch', 'Name', 'Nodes', 'Date']]
+            rows = [['ID', 'Date', 'Name', 'Nodes']]
             for batch in query.all():
+                nodes = [job.node for job in batch.jobs]
+                nodes_str = ','.join(nodes)
                 row = [
-                    batch.id, batch.__name__(), None, batch.created_date
+                    batch.id, batch.created_date, batch.__name__(),
+                    nodes_str
                 ]
                 rows.append(row)
             print(AsciiTable(rows).table)

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -54,8 +54,13 @@ def add_commands(appliance):
             query = session.query(Batch) \
                            .order_by(Batch.created_date.desc()) \
                            .limit(number)
+            rows = [['Batch', 'Name', 'Nodes', 'Date']]
             for batch in query.all():
-                print(batch.id)
+                row = [
+                    batch.id, batch.__name__(), None, batch.created_date
+                ]
+                rows.append(row)
+            print(AsciiTable(rows).table)
 
         finally:
             session.close()

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -33,7 +33,7 @@ class Job(Base):
                 connection = Connection(self.node)
                 try:
                     connection.open()
-                except NoValidConnectionsError as e:
+                except:
                     self.stderr = 'Could not establish ssh connection'
                     self.exit_code = -1
                 if connection.is_connected:


### PR DESCRIPTION
The `batch list` command will display the most recently ran batches. It limits its output to the last 10 batches by default, but this can be changed with `--number`.

It displays the batch that was ran and which nodes it was for.

Fixes #39 