### PR TITLE
Update the help and `Batch` model constructor fix

### DIFF
--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -16,10 +16,13 @@ def add_commands(appliance):
     def batch():
         pass
 
-    @batch.command(help='Filter the previously ran batches')
-    @click.option('--node', '-n')
-    @click.option('--group', '-g')
-    @click.option('--batch-id', '-i')
+    @batch.command(help='Retrieves the batch result summaries')
+    @click.option('--node', '-n',
+                  help='Retrieve the previous result for a node')
+    @click.option('--group', '-g',
+                  help='Retrieve the results for all nodes in group')
+    @click.option('--batch-id', '-i',
+                  help='Retrieve results for a particular batch')
     @click.pass_context
     def history(ctx, **options):
         set_nodes_context(ctx, **options)

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -17,11 +17,11 @@ def add_commands(appliance):
         pass
 
     @batch.command(help='Retrieves the batch result summaries')
-    @click.option('--node', '-n',
+    @click.option('--node', '-n', metavar='NODE',
                   help='Retrieve the previous result for a node')
-    @click.option('--group', '-g',
+    @click.option('--group', '-g', metavar='GROUP',
                   help='Retrieve the results for all nodes in group')
-    @click.option('--batch-id', '-i',
+    @click.option('--batch-id', '-i', metavar='ID',
                   help='Retrieve results for a particular batch')
     @click.pass_context
     def history(ctx, **options):
@@ -50,7 +50,7 @@ def add_commands(appliance):
         print(AsciiTable(table_rows()).table)
 
     @batch.command(help='List the recently ran batches')
-    @click.option('--number', '-n', default=10, type=int,
+    @click.option('--number', '-n', default=10, type=int, metavar='NUM',
                   help='Return the last NUM of batches')
     def list(number):
         session = Session()
@@ -99,8 +99,10 @@ def add_commands(appliance):
         print(table.table)
 
     @batch.group(help='Run a command on a node or group')
-    @click.option('--node', '-n', help='Runs the command on the node')
-    @click.option('--group', '-g', help='Runs the command over the group')
+    @click.option('--node', '-n', metavar='NODE',
+                  help='Runs the command on the node')
+    @click.option('--group', '-g', metavar='GROUP',
+                  help='Runs the command over the group')
     @click.pass_context
     def run(ctx, **kwargs):
         set_nodes_context(ctx, **kwargs)

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -12,11 +12,11 @@ from models.batch import Batch
 
 def add_commands(appliance):
 
-    @appliance.group(help='TODO')
+    @appliance.group(help='Manage running a command over the nodes')
     def batch():
         pass
 
-    @batch.command(help='TODO')
+    @batch.command(help='Filter the previously ran batches')
     @click.option('--node', '-n')
     @click.option('--group', '-g')
     @click.option('--batch-id', '-i')
@@ -46,7 +46,7 @@ def add_commands(appliance):
             return rows
         print(AsciiTable(table_rows()).table)
 
-    @batch.command(help='TODO')
+    @batch.command(help='List the recently ran batches')
     @click.option('--number', '-n', default=10, type=int)
     def list(number):
         session = Session()
@@ -68,7 +68,7 @@ def add_commands(appliance):
         finally:
             session.close()
 
-    @batch.command(help='TODO')
+    @batch.command(help='Inspect a previous batch')
     @click.argument('batch_id')
     @click.argument('node')
     def view(batch_id, node):
@@ -94,7 +94,7 @@ def add_commands(appliance):
         table.inner_row_border = True
         print(table.table)
 
-    @batch.group(help='TODO')
+    @batch.group(help='Run a command on a node or group')
     @click.option('--node', '-n')
     @click.option('--group', '-g')
     @click.pass_context

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -50,7 +50,8 @@ def add_commands(appliance):
         print(AsciiTable(table_rows()).table)
 
     @batch.command(help='List the recently ran batches')
-    @click.option('--number', '-n', default=10, type=int)
+    @click.option('--number', '-n', default=10, type=int,
+                  help='Return the last NUM of batches')
     def list(number):
         session = Session()
         try:
@@ -98,8 +99,8 @@ def add_commands(appliance):
         print(table.table)
 
     @batch.group(help='Run a command on a node or group')
-    @click.option('--node', '-n')
-    @click.option('--group', '-g')
+    @click.option('--node', '-n', help='Runs the command on the node')
+    @click.option('--group', '-g', help='Runs the command over the group')
     @click.pass_context
     def run(ctx, **kwargs):
         set_nodes_context(ctx, **kwargs)

--- a/src/commands/group.py
+++ b/src/commands/group.py
@@ -4,15 +4,15 @@ import groups
 
 def add_commands(appliance):
 
-    @appliance.group(help='TODO')
+    @appliance.group(help='View the adminware groups')
     def group():
         pass
 
-    @group.command(help='TODO')
+    @group.command(help='Lists the possible groups')
     def list():
         click.echo("\n".join(groups.list()))
 
-    @group.command(help='TODO')
+    @group.command(help='Gives the nodes within a group')
     @click.argument('group_name')
     def show(group_name):
         click.echo("\n".join(groups.nodes_in(group_name)))

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -11,7 +11,8 @@ from models.batch import Batch
 
 def add_commands(appliance):
 
-    @click.option('--node', '-n', required=True)
+    @click.option('--node', '-n', required=True, metavar='NODE',
+                  help='Runs the command on NODE')
     @click.pass_context
     def open_command(ctx, **kwargs):
         ctx.obj = { 'adminware' : { 'node' : kwargs['node'] } }

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -17,7 +17,9 @@ def add_commands(appliance):
         ctx.obj = { 'adminware' : { 'node' : kwargs['node'] } }
 
     open_command.__name__ = 'open'
-    open_command = appliance.group(help='TODO')(open_command)
+    open_command = appliance.group(
+                       help='Runs the command in an interactive shell'
+                   )(open_command)
 
     @ClickGlob.command(open_command, 'open')
     @click.pass_context

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -1,6 +1,6 @@
 
 import datetime
-from sqlalchemy import Column, String, Integer, DateTime
+from sqlalchemy import Column, String, Integer, DateTime, orm
 
 from database import Base
 from models.config import Config
@@ -25,4 +25,11 @@ class Batch(Base):
 
     def __init__(self, **kwargs):
         self.config = kwargs['config']
+        self.__init_or_load()
+
+    @orm.reconstructor
+    def __load(self):
+        self.__init_or_load()
+
+    def __init_or_load(self):
         self.config_model = Config(self.config)


### PR DESCRIPTION
This PR mostly updates the `CLI` help and fixes #46.

It also fixes a bug when a `Batch` model is loaded from the `db`, it skips the model initialisation. This is because the SQLAlchemy does not call the `__init__` method. Instead, a constructor has to be used instead.