### PR TITLE
Tweak batch flags and fix sandbox crash

### DIFF
--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -50,14 +50,14 @@ def add_commands(appliance):
         print(AsciiTable(table_rows()).table)
 
     @batch.command(help='List the recently ran batches')
-    @click.option('--number', '-n', default=10, type=int, metavar='NUM',
+    @click.option('--limit', '-l', default=10, type=int, metavar='NUM',
                   help='Return the last NUM of batches')
-    def list(number):
+    def list(limit):
         session = Session()
         try:
             query = session.query(Batch) \
                            .order_by(Batch.created_date.desc()) \
-                           .limit(number)
+                           .limit(limit)
             rows = [['ID', 'Date', 'Name', 'Nodes']]
             for batch in query.all():
                 nodes = [job.node for job in batch.jobs]

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -21,7 +21,7 @@ def add_commands(appliance):
                   help='Retrieve the previous result for a node')
     @click.option('--group', '-g', metavar='GROUP',
                   help='Retrieve the results for all nodes in group')
-    @click.option('--batch-id', '-i', metavar='ID',
+    @click.option('--batch-id', '-i', metavar='ID', type=int,
                   help='Retrieve results for a particular batch')
     @click.pass_context
     def history(ctx, **options):
@@ -73,7 +73,7 @@ def add_commands(appliance):
             session.close()
 
     @batch.command(help='Inspect a previous batch')
-    @click.argument('batch_id')
+    @click.argument('batch_id', type=int)
     @click.argument('node')
     def view(batch_id, node):
         session = Session()


### PR DESCRIPTION
This PR tweaks the `--limit` flag used in `batch list`, fixes #55. Also it specifies that the `batch-id` is an integer. This should fix the sandbox crash, fixes #54