### PR TITLE
Fix a sandbox crash bug and error if a group is missing

### DIFF
--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -1,9 +1,14 @@
 
 import groups
+from click import ClickException
 
 def set_nodes_context(ctx, **kwargs):
     obj = { 'nodes' : [] }
     if kwargs['node']: obj['nodes'].append(kwargs['node'])
     if kwargs['group']:
-        obj['nodes'].extend(groups.nodes_in(kwargs['group']))
+        group = kwargs['group']
+        nodes = groups.nodes_in(group)
+        if not nodes:
+            raise ClickException('Could not find group: {}'.format(group))
+        obj['nodes'].extend(nodes)
     ctx.obj = { 'adminware' : obj }

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -84,7 +84,7 @@ def add_commands(appliance):
                      .first()
         if job == None:
             click.echo('No job found', err=True)
-            exit(1)
+            return
         table_data = [
             ['Date', job.created_date],
             ['Batch', job.batch.id],

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -1,5 +1,6 @@
 
 import click
+from click import ClickException
 from action import ClickGlob
 import groups
 from terminaltables import AsciiTable
@@ -82,9 +83,7 @@ def add_commands(appliance):
                      .join(Job, Batch.jobs) \
                      .filter(Batch.id == int(batch_id)) \
                      .first()
-        if job == None:
-            click.echo('No job found', err=True)
-            return
+        if job == None: raise ClickException('No job found')
         table_data = [
             ['Date', job.created_date],
             ['Batch', job.batch.id],


### PR DESCRIPTION
The `cli_utils.set_node_context` function is responsible for converting the `--node` and `--group` flags into a list of nodes. It now errors if it does not recognise the `group`. fixes #52

Also the `ClickException` class is now being used to generate fatal errors. This allows for `click`'s inbuilt error handling to take over and prevents the sandbox from breaking. Fixes #53 