### PR TITLE
Add additional error handling/ output

### DIFF
--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -109,13 +109,16 @@ def add_commands(appliance):
     @ClickGlob.command(run, 'batch')
     @click.pass_context
     def run_batch(ctx, config):
+        nodes = ctx.obj['adminware']['nodes']
+        if not nodes:
+            raise ClickException('Please give either --node or --group')
         batch = Batch(config = config.path)
         session = Session()
         try:
             session.add(batch)
             session.commit() # Saves the batch to receive and id
             print("Batch: {}".format(batch.id))
-            for node in ctx.obj['adminware']['nodes']:
+            for node in nodes:
                 job = Job(node = node, batch = batch)
                 session.add(job)
                 job.run()

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -1,5 +1,6 @@
 
 import click
+from click import ClickException
 from action import ClickGlob
 from models.job import Job
 from models.batch import Batch
@@ -28,4 +29,6 @@ def add_commands(appliance):
         batch = Batch(config = config.path)
         job = Job(node = ctx.obj['adminware']['node'], batch = batch)
         job.run(interactive = True)
+        # Display the error if adminware errors (e.g. failed ssh connection)
+        if job.exit_code < 0: raise ClickException(job.stderr)
 


### PR DESCRIPTION
`batch run` now errors if no node/group are provided to it. Previously it would create an empty batch, which would be displayed in the `batch list`. Fixes #50 

Also, if an adminware error occurs on `open` (e.g. failed ssh connection), it is now displayed to the user. NOTE: that non-zero positive exit codes still fail silently as it can be assumed that the user was responsible for it.