### PR TITLE
Feat/add pagination

### DIFF
--- a/bin/run-cli
+++ b/bin/run-cli
@@ -7,4 +7,6 @@ set +u
 source venv/bin/activate
 set -u
 
+export LESSSECURE=1
+export LESS="-R -F"
 src/adminware "$@"

--- a/src/appliance_cli/text.py
+++ b/src/appliance_cli/text.py
@@ -39,8 +39,11 @@ def bold(text):
 
 
 def display_table(headers, data):
-    bolded_headers = [bold(header) for header in headers]
-    table_data = [bolded_headers] + data
+    if headers:
+        bolded_headers = [bold(header) for header in headers]
+        table_data = [bolded_headers] + data
+    else:
+        table_data = data
 
     # Issue with less displaying SingleTable so double is needed, appears NOT to be a unicode issue
     # TODO sort this ^

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -3,13 +3,13 @@ import click
 from click import ClickException
 from action import ClickGlob
 import groups
-from terminaltables import AsciiTable
 
 from cli_utils import set_nodes_context
 from database import Session
 
 from models.job import Job
 from models.batch import Batch
+from appliance_cli.text import display_table
 
 def add_commands(appliance):
 
@@ -39,8 +39,9 @@ def add_commands(appliance):
                          .filter(Batch.id == int(batch_id))
         jobs = query.all()
         jobs = sorted(jobs, key=lambda job: job.created_date, reverse=True)
+        headers = ['Batch', 'Node', 'Command', 'Exit Code', 'Date']
         def table_rows():
-            rows = [['Batch', 'Node', 'Command', 'Exit Code', 'Date']]
+            rows = []
             for job in jobs:
                 batch = job.batch
                 row = [batch.id,
@@ -50,7 +51,7 @@ def add_commands(appliance):
                        batch.created_date]
                 rows.append(row)
             return rows
-        print(AsciiTable(table_rows()).table)
+        display_table(headers, table_rows())
 
     @batch.command(help='List the recently ran batches')
     @click.option('--limit', '-l', default=10, type=int, metavar='NUM',
@@ -61,7 +62,9 @@ def add_commands(appliance):
             query = session.query(Batch) \
                            .order_by(Batch.created_date.desc()) \
                            .limit(limit)
-            rows = [['ID', 'Date', 'Name', 'Nodes']]
+            headers = ['ID', 'Date', 'Name', 'Nodes']
+            rows = []
+
             for batch in query.all():
                 nodes = [job.node for job in batch.jobs]
                 nodes_str = ','.join(nodes)
@@ -70,7 +73,7 @@ def add_commands(appliance):
                     nodes_str
                 ]
                 rows.append(row)
-            print(AsciiTable(rows).table)
+            display_table(headers, rows)
 
         finally:
             session.close()
@@ -95,9 +98,7 @@ def add_commands(appliance):
             ['STDOUT', job.stdout],
             ['STDERR', job.stderr]
         ]
-        table = AsciiTable(table_data)
-        table.inner_row_border = True
-        print(table.table)
+        display_table([], table_data)
 
     @batch.group(help='Run a command on a node or group')
     @click.option('--node', '-n', metavar='NODE',

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -120,7 +120,7 @@ def add_commands(appliance):
         try:
             session.add(batch)
             session.commit() # Saves the batch to receive and id
-            print("Batch: {}".format(batch.id))
+            output = "Batch: {}".format(batch.id)
             for node in nodes:
                 job = Job(node = node, batch = batch)
                 session.add(job)
@@ -129,7 +129,8 @@ def add_commands(appliance):
                     symbol = 'Pass'
                 else:
                     symbol = 'Failed: {}'.format(job.exit_code)
-                print("{}: {}".format(job.node, symbol))
+                output = output + "\n{}: {}".format(job.node, symbol)
+                click.echo_via_pager(output)
         finally:
             session.commit()
             session.close()

--- a/src/commands/group.py
+++ b/src/commands/group.py
@@ -10,9 +10,9 @@ def add_commands(appliance):
 
     @group.command(help='Lists the possible groups')
     def list():
-        click.echo("\n".join(groups.list()))
+        click.echo_via_pager("\n".join(groups.list()))
 
     @group.command(help='Gives the nodes within a group')
     @click.argument('group_name')
     def show(group_name):
-        click.echo("\n".join(groups.nodes_in(group_name)))
+        click.echo_via_pager("\n".join(groups.nodes_in(group_name)))


### PR DESCRIPTION
Closes #60 when merged 
This should enable pagination for all output that's potentially longer than a screen (though I'm still not fully familiar with the project so it's possible I've missed something), should exit if less than a screen & should  people from `rm -rf`ing within `less`
EDIT: I forgot to mention originally - my method for invoking less on the output of batch commands prevents incremental display. This is the same problem as with https://github.com/alces-software/userware/issues/42. If it would be preferred to have the output display as it's generated I can revert it or spend more time looking for a solution