### PR TITLE
Feat/tool arguments

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -12,6 +12,7 @@ class ClickGlob:
             paths = glob.glob(os.path.join(*parts))
             return list(map(lambda x: Action(x), paths))
 
+        # command_func is either run_open or run_batch, what this is decorating
         def __command(command_func):
             actions = __glob_actions(namespace)
             for action in actions:
@@ -27,11 +28,11 @@ class Action:
         self.config = Config(self.path)
 
     def create(self, click_group, command_func):
-        def action_func():
-            return command_func(self.config)
+        def action_func(arguments):
+            return command_func(self.config, arguments)
         action_func.__name__ = self.config.__name__()
         action_func = self.__click_command(action_func, click_group)
 
     def __click_command(self, func, click_group):
-        return click_group.command(help=self.config.help())(func)
+        return click.argument('arguments', nargs=-1)(click_group.command(help=self.config.help())(func))
 

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -110,11 +110,11 @@ def add_commands(appliance):
 
     @ClickGlob.command(run, 'batch')
     @click.pass_context
-    def run_batch(ctx, config):
+    def run_batch(ctx, config, arguments):
         nodes = ctx.obj['adminware']['nodes']
         if not nodes:
             raise ClickException('Please give either --node or --group')
-        batch = Batch(config = config.path)
+        batch = Batch(config = config.path, arguments = arguments)
         session = Session()
         try:
             session.add(batch)
@@ -132,4 +132,3 @@ def add_commands(appliance):
         finally:
             session.commit()
             session.close()
-

--- a/src/commands/group.py
+++ b/src/commands/group.py
@@ -4,7 +4,7 @@ import groups
 
 def add_commands(appliance):
 
-    @appliance.group(help='View the adminware groups')
+    @appliance.group(help='View the Adminware groups')
     def group():
         pass
 

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -23,8 +23,8 @@ def add_commands(appliance):
 
     @ClickGlob.command(open_command, 'open')
     @click.pass_context
-    def run_open(ctx, config):
-        batch = Batch(config = config.path)
+    def run_open(ctx, config, arguments):
+        batch = Batch(config = config.path, arguments = arguments)
         job = Job(node = ctx.obj['adminware']['node'], batch = batch)
         job.run(interactive = True)
         # Display the error if adminware errors (e.g. failed ssh connection)

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -9,11 +9,9 @@ from models.batch import Batch
 # other command modules, as this conflicts with Python's built-in `open`
 # function.
 
-
 def add_commands(appliance):
 
-    @click.option('--node', '-n', required=True, metavar='NODE',
-                  help='Runs the command on NODE')
+    @click.argument('node', nargs=1)
     @click.pass_context
     def open_command(ctx, **kwargs):
         ctx.obj = { 'adminware' : { 'node' : kwargs['node'] } }
@@ -31,4 +29,3 @@ def add_commands(appliance):
         job.run(interactive = True)
         # Display the error if adminware errors (e.g. failed ssh connection)
         if job.exit_code < 0: raise ClickException(job.stderr)
-

--- a/src/commands/open_command.py
+++ b/src/commands/open_command.py
@@ -18,7 +18,7 @@ def add_commands(appliance):
 
     open_command.__name__ = 'open'
     open_command = appliance.group(
-                       help='Runs the command in an interactive shell'
+                       help='Run a command in an interactive shell'
                    )(open_command)
 
     @ClickGlob.command(open_command, 'open')

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -11,6 +11,7 @@ class Batch(Base):
 
     id = Column(Integer, primary_key=True)
     config = Column(String)
+    arguments = Column(String)
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
 
 
@@ -25,6 +26,7 @@ class Batch(Base):
 
     def __init__(self, **kwargs):
         self.config = kwargs['config']
+        self.arguments = ' '. join(kwargs['arguments'])
         self.__init_or_load()
 
     @orm.reconstructor

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -81,6 +81,7 @@ class Job(Base):
                     else:
                         kwargs.update({ 'hide': 'both' })
                     cmd = self.batch.command()
+                    if self.batch.arguments: cmd = cmd + ' ' + self.batch.arguments
                     result = connection.run(cmd, **kwargs)
                     __set_result(result)
             __run_command()


### PR DESCRIPTION
It's taken a while but it has been done - commands can now take arguments
I've also taken the opportunity to change the `open` command syntax for consistency as per #59 
This may require a deletion of `/var/lib/adminware/database.db` as I've added a field to store a command's arguments in its batch
Closes #67 and #59 when merged