### PR TITLE
Feat/stack node arguments

### DIFF
--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -4,11 +4,13 @@ from click import ClickException
 
 def set_nodes_context(ctx, **kwargs):
     obj = { 'nodes' : [] }
-    if kwargs['node']: obj['nodes'].append(kwargs['node'])
+    if kwargs['node']:
+        for node in kwargs['node']:
+            obj['nodes'].append(node)
     if kwargs['group']:
-        group = kwargs['group']
-        nodes = groups.nodes_in(group)
-        if not nodes:
-            raise ClickException('Could not find group: {}'.format(group))
-        obj['nodes'].extend(nodes)
+        for group in kwargs['group']:
+            nodes = groups.nodes_in(group)
+            if not nodes:
+                raise ClickException('Could not find group: {}'.format(group))
+            obj['nodes'].extend(nodes)
     ctx.obj = { 'adminware' : obj }

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -1,6 +1,5 @@
 
 import groups
-import re
 from click import ClickException
 from collections import OrderedDict
 
@@ -8,11 +7,7 @@ def set_nodes_context(ctx, **kwargs):
     # populate ctx.obj with nodes
     obj = { 'nodes' : [] }
     if kwargs['node']:
-        for node in kwargs['node']:
-            if re.match(r'.*\[[0-9]+-[0-9]+\]$', node):
-                obj['nodes'] += __add_multiple_nodes(node)
-            else:
-                obj['nodes'].append(node)
+        obj['nodes'].extend(groups.expand_nodes(kwargs['node']))
     if kwargs['group']:
         for group in kwargs['group']:
             nodes = groups.nodes_in(group)
@@ -25,21 +20,3 @@ def set_nodes_context(ctx, **kwargs):
 def __remove_duplicates(target_list):
     # gone for the slightly more intensive method that preserves order for pretty output
     return OrderedDict((x, True) for x in target_list).keys()
-
-def __add_multiple_nodes(nodes):
-    prefix = re.sub(r'\[.*?$', '', nodes)
-    num_2 = re.search(r'-([0-9]+)]$', nodes).group(1)
-    num_1 = re.search(r'\[([0-9]+)-[0-9]+\]$', nodes).group(1)
-    if (num_1 > num_2) or not num_1.isdigit() or not num_2.isdigit():
-        raise ClickException('Invalid node range - {}{} to {}{}'.format(prefix, num_1, prefix, num_2))
-    else:
-        mid = ''
-        # allowing for padding 0s in the range
-        if re.match(r'^0', num_1):
-            mid = re.search(r'^(0+)', num_1).group(1)
-        nodes_list = []
-        i = int(num_1)
-        while i <= int(num_2):
-            nodes_list += [prefix + mid + str(i)]
-            i += 1
-        return nodes_list

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -1,5 +1,6 @@
 
 import groups
+import re
 from click import ClickException
 from collections import OrderedDict
 
@@ -8,7 +9,10 @@ def set_nodes_context(ctx, **kwargs):
     obj = { 'nodes' : [] }
     if kwargs['node']:
         for node in kwargs['node']:
-            obj['nodes'].append(node)
+            if re.match(r'.*\[[0-9]+-[0-9]+\]$', node):
+                obj['nodes'] += __add_multiple_nodes(node)
+            else:
+                obj['nodes'].append(node)
     if kwargs['group']:
         for group in kwargs['group']:
             nodes = groups.nodes_in(group)
@@ -21,3 +25,21 @@ def set_nodes_context(ctx, **kwargs):
 def __remove_duplicates(target_list):
     # gone for the slightly more intensive method that preserves order for pretty output
     return OrderedDict((x, True) for x in target_list).keys()
+
+def __add_multiple_nodes(nodes):
+    prefix = re.sub(r'\[.*?$', '', nodes)
+    num_2 = re.search(r'-([0-9]+)]$', nodes).group(1)
+    num_1 = re.search(r'\[([0-9]+)-[0-9]+\]$', nodes).group(1)
+    if (num_1 > num_2) or not num_1.isdigit() or not num_2.isdigit():
+        raise ClickException('Invalid node range - {}{} to {}{}'.format(prefix, num_1, prefix, num_2))
+    else:
+        mid = ''
+        # allowing for padding 0s in the range
+        if re.match(r'^0', num_1):
+            mid = re.search(r'^(0+)', num_1).group(1)
+        nodes_list = []
+        i = int(num_1)
+        while i <= int(num_2):
+            nodes_list += [prefix + mid + str(i)]
+            i += 1
+        return nodes_list

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -4,7 +4,7 @@ from click import ClickException
 from collections import OrderedDict
 
 def set_nodes_context(ctx, **kwargs):
-    # ctx.obj with nodes
+    # populate ctx.obj with nodes
     obj = { 'nodes' : [] }
     if kwargs['node']:
         for node in kwargs['node']:

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -1,8 +1,10 @@
 
 import groups
 from click import ClickException
+from collections import OrderedDict
 
 def set_nodes_context(ctx, **kwargs):
+    # ctx.obj with nodes
     obj = { 'nodes' : [] }
     if kwargs['node']:
         for node in kwargs['node']:
@@ -13,4 +15,9 @@ def set_nodes_context(ctx, **kwargs):
             if not nodes:
                 raise ClickException('Could not find group: {}'.format(group))
             obj['nodes'].extend(nodes)
+    obj['nodes'] = __remove_duplicates(obj['nodes'])
     ctx.obj = { 'adminware' : obj }
+
+def __remove_duplicates(target_list):
+    # gone for the slightly more intensive method that preserves order for pretty output
+    return OrderedDict((x, True) for x in target_list).keys()

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -101,9 +101,9 @@ def add_commands(appliance):
         display_table([], table_data)
 
     @batch.group(help='Run a command on node(s) or group(s)')
-    @click.option('--node', '-n', metavar='NODE',
+    @click.option('--node', '-n', multiple=True, metavar='NODE',
                   help='Runs the command on the node')
-    @click.option('--group', '-g', metavar='GROUP',
+    @click.option('--group', '-g', multiple=True, metavar='GROUP',
                   help='Runs the command over the group')
     @click.pass_context
     def run(ctx, **kwargs):

--- a/src/groups.py
+++ b/src/groups.py
@@ -1,15 +1,27 @@
 
+# all dependancy on nodeattr is to be located in this file
 from plumbum import local
-
-__nodeattr = local['nodeattr']['-f', '/var/lib/adminware/genders']
+from tempfile import NamedTemporaryFile
 
 def list():
-    groups = __nodeattr('-l').split("\n")
+    groups = __nodeattr()('-l').split("\n")
     groups.remove('')
     return groups
 
 def nodes_in(group_name):
-    nodes = __nodeattr('-n', group_name).split("\n")
+    nodes = __nodeattr()('-n', group_name).split("\n")
     nodes.remove('')
     return nodes
 
+def expand_nodes(node_list):
+    tmp_file = NamedTemporaryFile(dir='/tmp/')
+    with open(tmp_file.name, 'w') as fil:
+        fil.write('\n'.join(node_list))
+    nodes = __nodeattr(file_path=tmp_file.name)('--expand').split("\n")
+    # above split adds trailing empty string in array so
+    del nodes[-1]
+    return nodes
+
+def __nodeattr(file_path=None):
+    if file_path: return local['nodeattr']['-f', file_path]
+    else: return local['nodeattr']['-f', '/var/lib/adminware/genders']

--- a/src/groups.py
+++ b/src/groups.py
@@ -22,6 +22,5 @@ def expand_nodes(node_list):
     del nodes[-1]
     return nodes
 
-def __nodeattr(file_path=None):
-    if file_path: return local['nodeattr']['-f', file_path]
-    else: return local['nodeattr']['-f', '/var/lib/adminware/genders']
+def __nodeattr(file_path='/var/lib/adminware/genders'):
+    return local['nodeattr']['-f', file_path]

--- a/src/groups.py
+++ b/src/groups.py
@@ -15,8 +15,8 @@ def nodes_in(group_name):
 
 def expand_nodes(node_list):
     tmp_file = NamedTemporaryFile(dir='/tmp/')
-    with open(tmp_file.name, 'w') as fil:
-        fil.write('\n'.join(node_list))
+    with open(tmp_file.name, 'w') as f:
+        f.write('\n'.join(node_list))
     nodes = __nodeattr(file_path=tmp_file.name)('--expand').split("\n")
     # above split adds trailing empty string in array so
     del nodes[-1]


### PR DESCRIPTION
Closes #68 when merged
Now can have >1 nodes and >1 groups specified (in any order!) 
- the >1 groups wasn't asked for, I can remove that if it's not wanted?

Any duplicate nodes included after these are evaluated are removed so each is only executed on once (aliases notwithstanding)
Also node ranges are supported!
- `<string>[<num1>-<num2>]` format
- `node[1-4]` will result in `node1`, `node2`, `node3`, `node4`
- `node[001-4]` will result in `node001`, `node002`, `node003`, `node004`
- as will `node[001-004]`
- as will `node00[1-4]` (ofc)