### PR TITLE
Feat/command families

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ command: command_to_run
 # `help` displayed for command, or first line displayed when `help` displayed for
 # parent command (see http://click.pocoo.org/5/documentation/#help-texts).
 help: command_help
+
+# A list of any families that the command is in. A family is a group of commands that
+# can be executed with a single statement using `batch run-family`. Commands within a
+# family are executed in alphabetical order and each command is executed on every node
+# before the second command is executed on any.
+# This field is optional.
+families:
+ - family1
+ - family2
+ - etc..
 ```
 
 # Development setup

--- a/src/action.py
+++ b/src/action.py
@@ -7,16 +7,16 @@ from collections import defaultdict
 from itertools import chain
 
 class ClickGlob:
-    def __glob_actions(namespace):
+    def __glob_configs(namespace):
         parts = ['/var/lib/adminware/tools',
                  namespace, '*/config.yaml']
         paths = glob.glob(os.path.join(*parts))
-        return list(map(lambda x: Action(x), paths))
+        return list(map(lambda x: Config(x), paths))
 
     def command(click_group, namespace):
         # command_func is either run_open or run_batch, what this is decorating
         def __command(command_func):
-            actions = ClickGlob.__glob_actions(namespace)
+            actions = list(map(lambda x: Action(x), ClickGlob.__glob_configs(namespace)))
             for action in actions:
                 action.create(click_group, command_func)
 
@@ -24,47 +24,22 @@ class ClickGlob:
 
     def command_family(click_group, namespace):
         def __command_family(command_func):
-            actions = ClickGlob.__glob_actions(namespace)
-            families = []
-            for action in actions:
-                if action.get_families(): families += [action.get_families()]
-            families_dict = __combine_dicts(families)
-            for key in families_dict.keys():
-                __create_option(click_group, command_func, key, families_dict[key])
-
-        # when want to combine the family dictionaries - while concatenating duplicate values
-        def __combine_dicts(dicts):
-            families_dict = defaultdict(list)
-            for single_dict in dicts:
-                for k, v in single_dict.items():
-                    families_dict[k].append(v)
-            # sort each command family
-            for key in families_dict:
-                families_dict[key].sort()
-            return families_dict
-
-        def __create_option(click_group, command_func, family, commands):
-            def action_family_func():
-                return command_func(family, commands)
-            action_family_func.__name__ = (family)
-            action_family_func = click_group.command(
-                    help='Run the command family \'{}\''.format(family)
-                    )(action_family_func)
+            configs = ClickGlob.__glob_configs(namespace)
+            family_names = []
+            for config in configs:
+                if config.families(): family_names += config.families()
+            # remove dupicates
+            familiy_names = list(set(family_names))
+            families = list(map(lambda x: ActionFamily(x), family_names))
+            ActionFamily.set_configs(configs)
+            for family in families:
+                family.create(click_group, command_func)
 
         return __command_family
 
 class Action:
-    def __init__(self, path):
-        self.path = path
-        self.config = Config(self.path)
-
-    def get_families(self):
-        # return a dict of each family this action is in, pointing to this action's name
-        families = self.config.families()
-        family_dict = {}
-        for family in families:
-            family_dict[family] = self.config.__name__()
-        return family_dict
+    def __init__(self, config):
+        self.config = config
 
     def create(self, click_group, command_func):
         def action_func(arguments):
@@ -75,3 +50,27 @@ class Action:
     def __click_command(self, func, click_group):
         return click.argument('arguments', nargs=-1)(click_group.command(help=self.config.help())(func))
 
+
+class ActionFamily:
+    configs = []
+
+    def __init__(self, name):
+        self.name = name
+
+    def set_configs(configs):
+        ActionFamily.configs = configs
+
+    def get_members_configs(self):
+        members_configs = []
+        for config in ActionFamily.configs:
+            if self.name in config.families():
+                members_configs += [config]
+        return members_configs
+
+    def create(self, click_group, command_func):
+        def action_family_func():
+            return command_func(self.name, self.get_members_configs())
+        action_family_func.__name__ = self.name
+        action_family_func = click_group.command(
+             help='Run the command family \'{}\''.format(self.name)
+             )(action_family_func)

--- a/src/action.py
+++ b/src/action.py
@@ -74,3 +74,4 @@ class Action:
 
     def __click_command(self, func, click_group):
         return click.argument('arguments', nargs=-1)(click_group.command(help=self.config.help())(func))
+

--- a/src/action.py
+++ b/src/action.py
@@ -38,6 +38,9 @@ class ClickGlob:
             for single_dict in dicts:
                 for k, v in single_dict.items():
                     families_dict[k].append(v)
+            # sort each command family
+            for key in families_dict:
+                families_dict[key].sort()
             return families_dict
 
         def __create_option(click_group, command_func, family, commands):

--- a/src/action.py
+++ b/src/action.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from itertools import chain
 
 class ClickGlob:
-    def glob_actions(namespace):
+    def __glob_actions(namespace):
         parts = ['/var/lib/adminware/tools',
                  namespace, '*/config.yaml']
         paths = glob.glob(os.path.join(*parts))
@@ -16,7 +16,7 @@ class ClickGlob:
     def command(click_group, namespace):
         # command_func is either run_open or run_batch, what this is decorating
         def __command(command_func):
-            actions = ClickGlob.glob_actions(namespace)
+            actions = ClickGlob.__glob_actions(namespace)
             for action in actions:
                 action.create(click_group, command_func)
 
@@ -24,7 +24,7 @@ class ClickGlob:
 
     def command_family(click_group, namespace):
         def __command_family(command_func):
-            actions = ClickGlob.glob_actions(namespace)
+            actions = ClickGlob.__glob_actions(namespace)
             families = []
             for action in actions:
                 if action.get_families(): families += [action.get_families()]

--- a/src/action.py
+++ b/src/action.py
@@ -5,27 +5,48 @@ import os
 from models.config import Config
 
 class ClickGlob:
-    def command(click_group, namespace):
-        def __glob_actions(namespace):
-            parts = ['/var/lib/adminware/tools',
-                     namespace, '*/config.yaml']
-            paths = glob.glob(os.path.join(*parts))
-            return list(map(lambda x: Action(x), paths))
+    def glob_actions(namespace):
+        parts = ['/var/lib/adminware/tools',
+                 namespace, '*/config.yaml']
+        paths = glob.glob(os.path.join(*parts))
+        return list(map(lambda x: Action(x), paths))
 
+    def command(click_group, namespace):
         # command_func is either run_open or run_batch, what this is decorating
         def __command(command_func):
-            actions = __glob_actions(namespace)
+            actions = ClickGlob.glob_actions(namespace)
             for action in actions:
                 action.create(click_group, command_func)
 
         return __command
 
+    def command_family(click_group, namespace):
+        def __command_family(command_func):
+            actions = ClickGlob.glob_actions(namespace)
+            families = []
+            for action in actions:
+                if action.get_families(): families += action.get_families()
+            families = list(set(families))
+            for family in families:
+                __create_option(click_group, command_func, family)
 
+        def __create_option(click_group, command_func, family):
+            def action_family_func():
+                return command_func(family)
+            action_family_func.__name__ = (family)
+            action_family_func = click_group.command(
+                    help='Run the command family \'{}\''.format(family)
+                    )(action_family_func)
+
+        return __command_family
 
 class Action:
     def __init__(self, path):
         self.path = path
         self.config = Config(self.path)
+
+    def get_families(self):
+        return self.config.families()
 
     def create(self, click_group, command_func):
         def action_func(arguments):
@@ -35,4 +56,3 @@ class Action:
 
     def __click_command(self, func, click_group):
         return click.argument('arguments', nargs=-1)(click_group.command(help=self.config.help())(func))
-

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -129,14 +129,14 @@ def add_commands(appliance):
 
     @ClickGlob.command_family(run_family, 'batch')
     @click.pass_context
-    def run_batch_family(ctx, family, commands):
+    def run_batch_family(ctx, family, command_configs):
         nodes = ctx.obj['adminware']['nodes']
         if not nodes:
             raise ClickException('Please give either --node or --group')
         batches = []
-        for command in commands:
+        for config in command_configs:
             #create batch w/ relevant config for command
-            batches += [Batch(config='/var/lib/adminware/tools/batch/{}/config.yaml'.format(command))]
+            batches += [Batch(config=config.path)]
         execute_batch(batches, nodes)
 
     def execute_batch(batches, nodes):

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -26,7 +26,7 @@ class Batch(Base):
 
     def __init__(self, **kwargs):
         self.config = kwargs['config']
-        self.arguments = ' '. join(kwargs['arguments'])
+        if 'arguments' in kwargs: self.arguments = ' '. join(kwargs['arguments'])
         self.__init_or_load()
 
     @orm.reconstructor

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -23,3 +23,7 @@ class Config():
         self.data.setdefault('help', default)
         return self.data['help']
 
+    def families(self):
+        default = ''
+        self.data.setdefault('families', default)
+        return self.data['families']


### PR DESCRIPTION
Closes #69 when merged
Mostly explained in changes to README
 - crates new `run-family` batch command
- families a command is in are specified in that command's config
- commands in a family are executed alphabetically
- each command is executed on every node before moving on the second command (as a separate batch)