### PR TITLE
Fix/no genders error

### DIFF
--- a/src/groups.py
+++ b/src/groups.py
@@ -15,6 +15,9 @@ def nodes_in(group_name):
     return nodes
 
 def expand_nodes(node_list):
+    if any(map(lambda x: '.' in x, node_list)):
+        raise ClickException('Invalid nodename - cannot contain \'.\'')
+
     tmp_file = NamedTemporaryFile(dir='/tmp/')
     with open(tmp_file.name, 'w') as f:
         f.write('\n'.join(node_list))

--- a/src/groups.py
+++ b/src/groups.py
@@ -3,6 +3,7 @@
 from plumbum import local, ProcessExecutionError
 from tempfile import NamedTemporaryFile
 from click import ClickException
+from re import search
 
 def list():
     groups = __nodeattr(arguments=['-l'])
@@ -15,11 +16,15 @@ def nodes_in(group_name):
     return nodes
 
 def expand_nodes(node_list):
-    # intercept for to generate more useful error message
+    # intercept to generate a more useful error message
     #   before invalid nodenames are caught generically in __nodeattr
-    if any(map(lambda x: '.' in x or x.endswith('@'), node_list)):
-        raise ClickException('Invalid nodename - cannot contain \'.\' or end in \'@\'')
+    for node in node_list:
+        if search(r'[^A-z0-9,\[\]]',node):
+            raise ClickException(
+                    "Invalid nodename {} - may only contain alphanumerics, ',', '[' and ']'"
+                    .format(node))
 
+    # build and parse a genders file of the nodes
     tmp_file = NamedTemporaryFile(dir='/tmp/')
     with open(tmp_file.name, 'w') as f:
         f.write('\n'.join(node_list))

--- a/src/groups.py
+++ b/src/groups.py
@@ -15,8 +15,10 @@ def nodes_in(group_name):
     return nodes
 
 def expand_nodes(node_list):
-    if any(map(lambda x: '.' in x, node_list)):
-        raise ClickException('Invalid nodename - cannot contain \'.\'')
+    # intercept for to generate more useful error message
+    #   before invalid nodenames are caught generically in __nodeattr
+    if any(map(lambda x: '.' in x or x.endswith('@'), node_list)):
+        raise ClickException('Invalid nodename - cannot contain \'.\' or end in \'@\'')
 
     tmp_file = NamedTemporaryFile(dir='/tmp/')
     with open(tmp_file.name, 'w') as f:

--- a/src/groups.py
+++ b/src/groups.py
@@ -27,4 +27,4 @@ def __nodeattr(file_path='/var/lib/adminware/genders', arguments=[], split_char=
     try:
         return local['nodeattr']['-f', file_path](arguments).split(split_char)
     except ProcessExecutionError as e:
-        raise ClickException('Unable to process genders file -- {}'.format(e.stderr))
+        raise ClickException('Unable to process genders file -- {}'.format(e.stderr.rstrip()))

--- a/src/groups.py
+++ b/src/groups.py
@@ -1,15 +1,16 @@
 
 # all dependancy on nodeattr is to be located in this file
-from plumbum import local
+from plumbum import local, ProcessExecutionError
 from tempfile import NamedTemporaryFile
+from click import ClickException
 
 def list():
-    groups = __nodeattr()('-l').split("\n")
+    groups = __nodeattr(arguments=['-l'])
     groups.remove('')
     return groups
 
 def nodes_in(group_name):
-    nodes = __nodeattr()('-n', group_name).split("\n")
+    nodes = __nodeattr(arguments=['-n', group_name])
     nodes.remove('')
     return nodes
 
@@ -17,10 +18,13 @@ def expand_nodes(node_list):
     tmp_file = NamedTemporaryFile(dir='/tmp/')
     with open(tmp_file.name, 'w') as f:
         f.write('\n'.join(node_list))
-    nodes = __nodeattr(file_path=tmp_file.name)('--expand').split("\n")
+    nodes = __nodeattr(file_path=tmp_file.name, arguments=['--expand'])
     # above split adds trailing empty string in array so
     del nodes[-1]
     return nodes
 
-def __nodeattr(file_path='/var/lib/adminware/genders'):
-    return local['nodeattr']['-f', file_path]
+def __nodeattr(file_path='/var/lib/adminware/genders', arguments=[], split_char="\n"):
+    try:
+        return local['nodeattr']['-f', file_path](arguments).split(split_char)
+    except ProcessExecutionError as e:
+        raise ClickException('Unable to process genders file -- {}'.format(e.stderr))


### PR DESCRIPTION
Fixes #71 and #81 when merged
- Move all `__nodeattr` code into a single method with more params so it can be surrounded by a single `try-except` block
- intercept any invalid nodenames before this execution is tried to a) prevent injection attacks b) give more informative error msgs

How do you feel about the use of regex to sanitize nodenames? William mentioned using click but I wasn't really sure what how I would go about doing that 
Did these in the same branch as they both dealt with the genders file - i know this isn't optimum, sorry