### PR TITLE
Feat/multiple namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ save the anything to the database.
 
 Commands are automatically picked up from config files stored within:
 
-`/var/lib/adminware/tools/{batch,open}/<command-name>/config.yaml`
+`/var/lib/adminware/tools/{batch,open}/[optional-other-directories/]<command-name>/config.yaml`
+
+The config.yaml files cannot have directories as their siblings, although
+there can be other files in the same directories.
 
 The config files should follow the following format:
 ```
@@ -34,7 +37,7 @@ help: command_help
 # can be executed with a single statement using `batch run-family`. Commands within a
 # family are executed in alphabetical order and each command is executed on every node
 # before the second command is executed on any.
-# This field is optional.
+# This field is optional and only valid for batch commands.
 families:
  - family1
  - family2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ save the anything to the database.
 
 Commands are automatically picked up from config files stored within:
 
-`/var/lib/adminware/tools/{batch,open}/[optional-other-directories/]<command-name>/config.yaml`
+`/var/lib/adminware/tools/{batch,open}/[<optional-namespace>/].../<command-name>/config.yaml`
 
 The config.yaml files cannot have directories as their siblings, although
 there can be other files in the same directories.

--- a/src/action.py
+++ b/src/action.py
@@ -9,8 +9,8 @@ from itertools import chain
 class ClickGlob:
     def __glob_configs(namespace):
         parts = ['/var/lib/adminware/tools',
-                 namespace, '*/config.yaml']
-        paths = glob.glob(os.path.join(*parts))
+                 namespace, '**/config.yaml']
+        paths = glob.glob(os.path.join(*parts), recursive=True)
         return list(map(lambda x: Config(x), paths))
 
     def command(click_group, namespace):

--- a/src/action.py
+++ b/src/action.py
@@ -1,3 +1,4 @@
+
 import glob
 import click
 import re
@@ -9,8 +10,7 @@ from itertools import chain
 
 class ClickGlob:
     #TODO possibly combine __glob_all_configs & __glob_dirs into one method to
-    # ensure consistent results are generated.
-    # likely with a decorator for __glob_dirs
+    # ensure consistent results are generated. Likely with a decorator for __glob_dirs.
     def __glob_all_configs(namespace):
         #TODO DRY up the file leader - only define '/var/lib/adminware/tools' once
         parts = ['/var/lib/adminware/tools',
@@ -37,6 +37,7 @@ class ClickGlob:
                     if any(map(lambda x: isdir(join(path, x)), listdir(path))):
                         raise RuntimeError("Directory detected sibling to a config.yaml file at {}\n".format(path)
                                 + "This is invalid, please rectify it before continuing")
+
                     action = Action(Config('{}/config.yaml'.format(path)))
                     action.create(cur_group, command_func)
                 else:

--- a/src/action.py
+++ b/src/action.py
@@ -3,6 +3,7 @@ import glob
 import click
 import re
 
+from sys import exit
 from os import listdir
 from os.path import join, dirname, relpath, isfile, isdir
 from models.config import Config
@@ -47,8 +48,9 @@ class ClickGlob:
                     # if there exists a sibling dir to any config.yaml this is currently an error
                     # TODO this will be removed with closure of issue #49 but more validation may be needed
                     if any(map(lambda x: isdir(join(path, x)), listdir(path))):
-                        raise RuntimeError("Directory detected sibling to a config.yaml file at {}\n".format(path)
-                                + "This is invalid, please rectify it before continuing")
+                        print('config.yaml file with directory as sibling detected at {}\n'.format(path)
+                                + 'This is invalid, please rectify it before continuing')
+                        exit(1)
 
                     action = Action(Config('{}/config.yaml'.format(path)))
                     action.create(cur_group, command_func)

--- a/src/action.py
+++ b/src/action.py
@@ -48,7 +48,6 @@ class ClickGlob:
             for path in paths:
                 if isfile(ClickGlob.join_config(path)):
                     # if there exists a sibling dir to any config.yaml this is currently an error
-                    # TODO this will be removed with closure of issue #49 but more validation may be needed
                     if any(map(lambda x: isdir(join(path, x)), listdir(path))):
                         click.echo('config.yaml file with directory as sibling detected at {}\n'.format(path)
                                 + 'This is invalid, please rectify it before continuing')

--- a/src/action.py
+++ b/src/action.py
@@ -2,6 +2,7 @@
 import glob
 import click
 import re
+import config
 
 from sys import exit
 from os import listdir
@@ -10,10 +11,9 @@ from models.config import Config
 from collections import defaultdict
 from itertools import chain
 
-#TODO DRY up the file leader - only define '/var/lib/adminware/tools' once
 class ClickGlob:
     def __glob_dirs(namespace):
-        parts = ['/var/lib/adminware/tools', namespace, '*']
+        parts = [config.LEADER, config.TOOL_LOCATION, namespace, '*']
         paths = glob.glob(join(*parts))
         return paths
 
@@ -26,7 +26,7 @@ class ClickGlob:
                     if isfile('{}/config.yaml'.format(path)):
                         kwargs['all_paths'] += [join(path, 'config.yaml')]
                     else:
-                        namespace = path[len('/var/lib/adminware/tools/'):]
+                        namespace = path[len(config.LEADER + config.TOOL_LOCATION):]
                         __sub_wrapper(namespace, **kwargs)
                 return kwargs['all_paths']
 
@@ -54,13 +54,16 @@ class ClickGlob:
                     action.create(cur_group, command_func)
                 else:
                     if isdir(path):
-                        regex_expr = r'\/var\/lib\/adminware\/tools\/' + re.escape(cur_namespace) + r'\/(.*$)'
+                        regex_expr = re.escape(config.LEADER) + \
+                                re.escape(config.TOOL_LOCATION) + \
+                                re.escape(cur_namespace) + \
+                                r'\/(.*$)'
                         new_namespace_bottom = re.search(regex_expr, path).group(1)
                         new_namespace = join(cur_namespace, new_namespace_bottom)
 
                         @cur_group.group(new_namespace_bottom,
-                                 help="Descend into the {} namespace".format(new_namespace_bottom)
-                                 )
+                                help="Descend into the {} namespace".format(new_namespace_bottom)
+                                )
                         def new_group():
                             pass
 

--- a/src/action.py
+++ b/src/action.py
@@ -13,7 +13,7 @@ from itertools import chain
 
 class ClickGlob:
     def __glob_dirs(namespace):
-        new_dir = join(config.LEADER, config.TOOL_LOCATION, namespace)
+        new_dir = config.join_with_tool_location(namespace)
         if isdir(new_dir):
             parts = listdir(new_dir)
             paths = list(map(lambda x: join(new_dir, x), parts))
@@ -79,10 +79,7 @@ class ClickGlob:
         return __command_family
 
     def __make_group(path, cur_group, cur_namespace):
-        regex_expr = re.escape(config.LEADER) + \
-                re.escape(config.TOOL_LOCATION) + \
-                re.escape(cur_namespace) + \
-                r'\/(.*$)'
+        regex_expr = re.escape(config.join_with_tool_location(cur_namespace)) + r'\/(.*$)'
         new_namespace_bottom = re.search(regex_expr, path).group(1)
         new_namespace = join(cur_namespace, new_namespace_bottom)
 

--- a/src/action.py
+++ b/src/action.py
@@ -27,8 +27,8 @@ class ClickGlob:
             def __sub_wrapper(*args, **kwargs):
                 paths = globbing_func(*args)
                 for path in paths:
-                    if isfile('{}/config.yaml'.format(path)):
-                        kwargs['all_paths'] += [join(path, 'config.yaml')]
+                    if isfile(ClickGlob.join_config(path)):
+                        kwargs['all_paths'] += [ClickGlob.join_config(path)]
                     else:
                         namespace = path[len(config.LEADER + config.TOOL_LOCATION):]
                         __sub_wrapper(namespace, **kwargs)
@@ -46,7 +46,7 @@ class ClickGlob:
         def __command_helper(cur_group, cur_namespace, command_func):
             paths = ClickGlob.__glob_dirs(cur_namespace) # will generate a list of paths at level 'namespace'
             for path in paths:
-                if isfile('{}/config.yaml'.format(path)):
+                if isfile(ClickGlob.join_config(path)):
                     # if there exists a sibling dir to any config.yaml this is currently an error
                     # TODO this will be removed with closure of issue #49 but more validation may be needed
                     if any(map(lambda x: isdir(join(path, x)), listdir(path))):
@@ -54,7 +54,7 @@ class ClickGlob:
                                 + 'This is invalid, please rectify it before continuing')
                         exit(1)
 
-                    action = Action(Config('{}/config.yaml'.format(path)))
+                    action = Action(Config(ClickGlob.join_config(path)))
                     action.create(cur_group, command_func)
                 else:
                     if isdir(path):
@@ -90,6 +90,9 @@ class ClickGlob:
             pass
 
         return (new_group, new_namespace)
+
+    def join_config(path):
+        return join(path, 'config.yaml')
 
 
 class Action:

--- a/src/action.py
+++ b/src/action.py
@@ -58,20 +58,7 @@ class ClickGlob:
                     action.create(cur_group, command_func)
                 else:
                     if isdir(path):
-                        regex_expr = re.escape(config.LEADER) + \
-                                re.escape(config.TOOL_LOCATION) + \
-                                re.escape(cur_namespace) + \
-                                r'\/(.*$)'
-                        new_namespace_bottom = re.search(regex_expr, path).group(1)
-                        new_namespace = join(cur_namespace, new_namespace_bottom)
-
-                        @cur_group.group(new_namespace_bottom,
-                                help="Descend into the {} namespace".format(new_namespace_bottom)
-                                )
-                        def new_group():
-                            pass
-
-                        __command_helper(new_group, new_namespace, command_func)
+                        __command_helper(*ClickGlob.__make_group(path, cur_group, cur_namespace), command_func)
 
         return __command
 
@@ -90,6 +77,23 @@ class ClickGlob:
                 family.create(click_group, command_func)
 
         return __command_family
+
+    def __make_group(path, cur_group, cur_namespace):
+        regex_expr = re.escape(config.LEADER) + \
+                re.escape(config.TOOL_LOCATION) + \
+                re.escape(cur_namespace) + \
+                r'\/(.*$)'
+        new_namespace_bottom = re.search(regex_expr, path).group(1)
+        new_namespace = join(cur_namespace, new_namespace_bottom)
+
+        @cur_group.group(new_namespace_bottom,
+                help="Descend into the {} namespace".format(new_namespace_bottom)
+                )
+        def new_group():
+            pass
+
+        return (new_group, new_namespace)
+
 
 class Action:
     def __init__(self, config):

--- a/src/action.py
+++ b/src/action.py
@@ -44,13 +44,14 @@ class ClickGlob:
                     new_namespace_bottom = re.search(regex_expr, path).group(1)
                     new_namespace = join(cur_namespace, new_namespace_bottom)
 
-                    @cur_group.group(new_namespace_bottom,
-                             help="Descend into the {} namespace".format(new_namespace_bottom)
-                             )
-                    def new_group():
-                        pass
+                    if isdir(path):
+                        @cur_group.group(new_namespace_bottom,
+                                 help="Descend into the {} namespace".format(new_namespace_bottom)
+                                 )
+                        def new_group():
+                            pass
 
-                    __command_helper(new_group, new_namespace, command_func)
+                        __command_helper(new_group, new_namespace, command_func)
 
         return __command
 

--- a/src/action.py
+++ b/src/action.py
@@ -30,9 +30,7 @@ class ClickGlob:
                         __sub_wrapper(namespace, **kwargs)
                 return kwargs['all_paths']
 
-            kwargs['all_paths']=[]
-            all_paths = __sub_wrapper(*args, **kwargs)
-            return all_paths
+            return __sub_wrapper(*args, **kwargs)
 
         return __wrapper
 
@@ -55,11 +53,11 @@ class ClickGlob:
                     action = Action(Config('{}/config.yaml'.format(path)))
                     action.create(cur_group, command_func)
                 else:
-                    regex_expr = r'\/var\/lib\/adminware\/tools\/' + re.escape(cur_namespace) + r'\/(.*$)'
-                    new_namespace_bottom = re.search(regex_expr, path).group(1)
-                    new_namespace = join(cur_namespace, new_namespace_bottom)
-
                     if isdir(path):
+                        regex_expr = r'\/var\/lib\/adminware\/tools\/' + re.escape(cur_namespace) + r'\/(.*$)'
+                        new_namespace_bottom = re.search(regex_expr, path).group(1)
+                        new_namespace = join(cur_namespace, new_namespace_bottom)
+
                         @cur_group.group(new_namespace_bottom,
                                  help="Descend into the {} namespace".format(new_namespace_bottom)
                                  )
@@ -73,7 +71,7 @@ class ClickGlob:
     def command_family(click_group, namespace):
         def __command_family(command_func):
             __glob_all_dirs = ClickGlob.__glob_all(ClickGlob.__glob_dirs)
-            configs = list(map(lambda x: Config(x), __glob_all_dirs(namespace)))
+            configs = list(map(lambda x: Config(x), __glob_all_dirs(namespace, all_paths=[])))
             family_names = []
             for config in configs:
                 if config.families(): family_names += config.families()

--- a/src/action.py
+++ b/src/action.py
@@ -13,9 +13,13 @@ from itertools import chain
 
 class ClickGlob:
     def __glob_dirs(namespace):
-        parts = [config.LEADER, config.TOOL_LOCATION, namespace, '*']
-        paths = glob.glob(join(*parts))
-        return paths
+        new_dir = join(config.LEADER, config.TOOL_LOCATION, namespace)
+        if isdir(new_dir):
+            parts = listdir(new_dir)
+            paths = list(map(lambda x: join(new_dir, x), parts))
+            return paths
+        else:
+            return []
 
     # decorator for __glob_dir to get all valid paths (ending in config.yaml) at once
     def __glob_all(globbing_func):

--- a/src/action.py
+++ b/src/action.py
@@ -50,7 +50,7 @@ class ClickGlob:
                     # if there exists a sibling dir to any config.yaml this is currently an error
                     # TODO this will be removed with closure of issue #49 but more validation may be needed
                     if any(map(lambda x: isdir(join(path, x)), listdir(path))):
-                        print('config.yaml file with directory as sibling detected at {}\n'.format(path)
+                        click.echo('config.yaml file with directory as sibling detected at {}\n'.format(path)
                                 + 'This is invalid, please rectify it before continuing')
                         exit(1)
 

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -120,9 +120,9 @@ def add_commands(appliance):
         execute_batch(batch, nodes)
 
     @batch.group(name='run-family', help='Run a family of commands on node(s) or group(s)')
-    @click.option('--node', '-n', metavar='NODE',
+    @click.option('--node', '-n', multiple=True, metavar='NODE',
               help='Runs the command on the node')
-    @click.option('--group', '-g', metavar='GROUP',
+    @click.option('--group', '-g', multiple=True, metavar='GROUP',
               help='Runs the command over the group')
     @click.pass_context
     def run_family(ctx, **kwargs):

--- a/src/config.py
+++ b/src/config.py
@@ -2,6 +2,8 @@
 import appliance_cli.config
 import appliance_cli.text as text
 
+from os.path import join
+
 
 # Create Adminware CLI config object.
 # Nothing special here for now, possibly overcomplicated due to adapting from
@@ -17,3 +19,6 @@ CONFIG = appliance_cli.config.finalize_config(_STANDARD_CONFIG)
 LEADER = '/var/lib/adminware/'
 
 TOOL_LOCATION = 'tools/'
+
+def join_with_tool_location(namespace):
+    return join(LEADER, TOOL_LOCATION, namespace)

--- a/src/config.py
+++ b/src/config.py
@@ -13,3 +13,7 @@ _APPLIANCE_TYPE = 'adminware'
 _STANDARD_CONFIG = appliance_cli.config.create_config_dict(_APPLIANCE_TYPE)
 
 CONFIG = appliance_cli.config.finalize_config(_STANDARD_CONFIG)
+
+LEADER = '/var/lib/adminware/'
+
+TOOL_LOCATION = 'tools/'

--- a/src/database.py
+++ b/src/database.py
@@ -1,9 +1,11 @@
 
+import config
+
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-engine = create_engine('sqlite:////var/lib/adminware/database.db')
+engine = create_engine('sqlite:///{}database.db'.format(config.LEADER))
 Session = sessionmaker(bind=engine)
 
 Base = declarative_base()

--- a/src/groups.py
+++ b/src/groups.py
@@ -1,5 +1,7 @@
 
 # all dependancy on nodeattr is to be located in this file
+import config
+
 from plumbum import local, ProcessExecutionError
 from tempfile import NamedTemporaryFile
 from click import ClickException
@@ -33,7 +35,7 @@ def expand_nodes(node_list):
     del nodes[-1]
     return nodes
 
-def __nodeattr(file_path='/var/lib/adminware/genders', arguments=[], split_char="\n"):
+def __nodeattr(file_path='{}genders'.format(config.LEADER), arguments=[], split_char="\n"):
     try:
         return local['nodeattr']['-f', file_path](arguments).split(split_char)
     except ProcessExecutionError as e:


### PR DESCRIPTION
Closes #48 when merged

Tools can now be located in arbitrarily deeply nested file systems within `/var/lib/adminware/tools/{batch,open}` These extended file systems come up as autocomplete results in the CLI.

Also added some validation for the file system - any dir containing a config.yaml and another dir will throw a big ol' error on start up. Any file in the tree will now not register as a result in the CLI.

Also fixed multiple node arguments for `run-family` (oopsie)