### PR TITLE
alter default command behaviour

### DIFF
--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -24,6 +24,9 @@ class Batch(Base):
     def command(self):
         return self.config_model.command()
 
+    def command_exists(self):
+        return self.config_model.command_exists()
+
     def __init__(self, **kwargs):
         self.config = kwargs['config']
         if 'arguments' in kwargs: self.arguments = ' '. join(kwargs['arguments'])

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -14,7 +14,7 @@ class Config():
 
     def command(self):
         n = self.__name__()
-        default = 'echo "No command given for: {}"'.format(n)
+        default = ''
         self.data.setdefault('command', default)
         return self.data['command']
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1,8 +1,6 @@
 import yaml
 import os
 
-from click import ClickException
-
 class Config():
     def __init__(self, path):
         self.path = path
@@ -15,8 +13,6 @@ class Config():
         return os.path.basename(os.path.dirname(self.path))
 
     def command(self):
-        if 'command' not in self.data:
-            raise ClickException('{} has no valid command'.format(self.__name__()))
         return self.data['command']
 
     def help(self):
@@ -28,3 +24,6 @@ class Config():
         default = ''
         self.data.setdefault('families', default)
         return self.data['families']
+
+    def command_exists(self):
+        return 'command' in self.data

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -14,7 +14,7 @@ class Config():
 
     def command(self):
         n = self.__name__()
-        default = ''
+        default = 'No command set'
         self.data.setdefault('command', default)
         return self.data['command']
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1,6 +1,8 @@
 import yaml
 import os
 
+from click import ClickException
+
 class Config():
     def __init__(self, path):
         self.path = path
@@ -13,9 +15,8 @@ class Config():
         return os.path.basename(os.path.dirname(self.path))
 
     def command(self):
-        n = self.__name__()
-        default = 'No command set'
-        self.data.setdefault('command', default)
+        if 'command' not in self.data:
+            raise ClickException('{} has no valid command'.format(self.__name__()))
         return self.data['command']
 
     def help(self):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -26,4 +26,4 @@ class Config():
         return self.data['families']
 
     def command_exists(self):
-        return 'command' in self.data
+        return 'command' in self.data and self.data['command']

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -29,6 +29,15 @@ class Job(Base):
 
 
     def run(self, interactive=False):
+        def __check_command(func):
+            def wrapper():
+                if self.batch.command_exists():
+                    func()
+                else:
+                    self.stderr = 'Incorrectly conifgured command'
+                    self.exit_code = -2
+            return wrapper
+
         def __with_connection(func):
             def wrapper():
                 connection = Connection(self.node)
@@ -44,6 +53,7 @@ class Job(Base):
                         connection.close()
             return wrapper
 
+        @__check_command
         @__with_connection
         def __runner(connection):
             def __set_result(result):


### PR DESCRIPTION
~Changed it from `echo 'no command specified <tool name>'` to the empty string (an invalid bash command) so it now reports a failure~
```
adminware> batch run -n localhost test_cmd6
Batch: 415
Executing: test_cmd6
localhost: Failed: 1
```

Ignore the above, I had forgotten about `open`. Now the default is a static string and as such using `open` with an invalid command reports 'Command not found' . `batch` reports the same as above except with error code 127
I am a little ignorant, is this what people want? If not how would you want the failure communicated?
Fixes #84 when merged