### PR TITLE
Give tmp file a prefix

### DIFF
--- a/src/groups.py
+++ b/src/groups.py
@@ -25,7 +25,7 @@ def expand_nodes(node_list):
                     .format(node))
 
     # build and parse a genders file of the nodes
-    tmp_file = NamedTemporaryFile(dir='/tmp/')
+    tmp_file = NamedTemporaryFile(dir='/tmp/', prefix='adminware-genders')
     with open(tmp_file.name, 'w') as f:
         f.write('\n'.join(node_list))
     nodes = __nodeattr(file_path=tmp_file.name, arguments=['--expand'])


### PR DESCRIPTION
Fixes #78 
an example file path is now `/tmp/adminware-genders-ktgnha48`