### PR TITLE
Remove paramiko requirement

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -14,7 +14,6 @@ invoke==1.2.0
 ipython==5.3.0
 ipython-genutils==0.1.0
 packaging==16.8
-paramiko==2.4.1
 pexpect==4.2.1
 pickleshare==0.7.4
 plumbum==1.6.7

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -14,6 +14,7 @@ invoke==1.2.0
 ipython==5.3.0
 ipython-genutils==0.1.0
 packaging==16.8
+paramiko==2.4.2
 pexpect==4.2.1
 pickleshare==0.7.4
 plumbum==1.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ invoke==1.2.0
 ipython==5.3.0
 ipython-genutils==0.1.0
 packaging==16.8
-paramiko==2.4.1
 pexpect==4.2.1
 pickleshare==0.7.4
 plumbum==1.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ invoke==1.2.0
 ipython==5.3.0
 ipython-genutils==0.1.0
 packaging==16.8
+paramiko==2.4.2
 pexpect==4.2.1
 pickleshare==0.7.4
 plumbum==1.6.7

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -3,8 +3,6 @@ from fabric import Connection
 import os
 import glob
 
-from paramiko.ssh_exception import NoValidConnectionsError
-
 import datetime
 from shlex import quote
 from sqlalchemy import Column, String, Integer, DateTime, ForeignKey


### PR DESCRIPTION
It's only use was an import that was never referenced again (also
removed)
A version (>=2.4) is required by fabric but this should be fine
Setup seems to be fine with new requirements but please tell me if i've broken anything, not at all impossible