### PR TITLE
Feat/node log

### DIFF
--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -114,6 +114,7 @@ def add_commands(appliance):
                            .order_by(Job.created_date.desc())\
                            .group_by(Batch.config)\
                            .all()
+        if not job_query: raise ClickException('No jobs found for node {}'.format(node))
         #returns tuples of config_paths + the number of times that config's been run on <node>
         commmand_count_query = session.query(Batch.config, func.count(Batch.config))\
                                       .join(Job.batch)\
@@ -123,7 +124,6 @@ def add_commands(appliance):
                                       .all()
         headers = ['Command', 'Last Batch ID', 'Last Exit Code', 'Date', 'Arguments', 'Times Ran']
         rows = []
-        #I'm aware this isn't particularly pythonic, any ideas?
         for i in range(len(job_query)):
             command = job_query[i]
             arguments = None if not command.batch.arguments else command.batch.arguments

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -117,21 +117,22 @@ def add_commands(appliance):
                            .all()
         if not job_query: raise ClickException('No jobs found for node {}'.format(node))
         headers = ['Command',
-                   'Last Batch ID',
-                   'Last Exit Code',
-                   'Date',
+                   'Exit Code',
+                   'Batch',
                    'Arguments',
-                   'Times Ran']
+                   'Date',
+                   'No. Reruns']
+
         rows = []
         for command in job_query:
             count = command[1]
             command = command[0]
             arguments = None if not command.batch.arguments else command.batch.arguments
             row = [command.batch.__name__(),
-                   command.batch.id,
                    command.exit_code,
-                   command.created_date,
+                   command.batch.id,
                    arguments,
+                   command.created_date,
                    count]
             rows += [row]
             # sort by command name

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -116,14 +116,23 @@ def add_commands(appliance):
                            .group_by(Batch.config)\
                            .all()
         if not job_query: raise ClickException('No jobs found for node {}'.format(node))
-        headers = ['Command', 'Last Batch ID', 'Last Exit Code', 'Date', 'Arguments', 'Times Ran']
+        headers = ['Command',
+                   'Last Batch ID',
+                   'Last Exit Code',
+                   'Date',
+                   'Arguments',
+                   'Times Ran']
         rows = []
         for command in job_query:
             count = command[1]
             command = command[0]
             arguments = None if not command.batch.arguments else command.batch.arguments
-            row = [command.batch.__name__(), command.batch.id, command.exit_code,
-                    command.created_date, arguments, count]
+            row = [command.batch.__name__(),
+                   command.batch.id,
+                   command.exit_code,
+                   command.created_date,
+                   arguments,
+                   count]
             rows += [row]
             # sort by command name
             rows.sort(key=lambda x:x[0])


### PR DESCRIPTION
EDIT: Fixes #101 
Add new command for retrieving a history of commands ran on a single node
Currently listed under `batch node-log NODE` as it's only relevant to batch commands, they're the only ones that are committed to the db
- this is liable to be changed when we update usability

```
adminware> batch node-log localhost
╔════════════╦═══════════════╦════════════════╦════════════════════════════╦═══════════╦═══════════╗
║ Command    ║ Last Batch ID ║ Last Exit Code ║ Date                       ║ Arguments ║ Times Ran ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ new_test   ║ 250           ║ 0              ║ 2018-10-23 14:50:27.807623 ║ None      ║ 1         ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ pgrep      ║ 252           ║ 2              ║ 2018-10-24 10:53:14.956108 ║ None      ║ 2         ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ steve      ║ 226           ║ 0              ║ 2018-10-18 16:43:48.341738 ║ None      ║ 9         ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ test_cmd10 ║ 253           ║ None           ║ 2018-10-24 13:30:37.074175 ║ None      ║ 13        ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ test_cmd11 ║ 249           ║ 0              ║ 2018-10-23 11:36:39.463931 ║ None      ║ 13        ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ test_cmd3  ║ 247           ║ 0              ║ 2018-10-23 11:36:38.246693 ║ None      ║ 32        ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ test_cmd5  ║ 242           ║ 0              ║ 2018-10-23 11:35:59.893082 ║ None      ║ 17        ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ test_cmd6  ║ 229           ║ -2             ║ 2018-10-23 10:54:07.187795 ║ None      ║ 50        ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ test_cmd8  ║ 248           ║ 0              ║ 2018-10-23 11:36:38.831787 ║ None      ║ 12        ║
╠════════════╬═══════════════╬════════════════╬════════════════════════════╬═══════════╬═══════════╣
║ test_cmd9  ║ 230           ║ 0              ║ 2018-10-23 10:54:07.696828 ║ None      ║ 13        ║
╚════════════╩═══════════════╩════════════════╩════════════════════════════╩═══════════╩═══════════╝
```