### PR TITLE
Run each job within a separate thread

### DIFF
--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -243,6 +243,7 @@ def add_commands(appliance):
                 session.commit()
                 click.echo('Batch: {}\nExecuting: {}'.format(batch.id, batch.__name__()))
                 threads = list(map(lambda n: JobRunner(n, batch).thread, nodes))
+                threads.reverse()
                 active_threads = []
                 while len(threads) > 0 or len(active_threads) > 0:
                     while len(active_threads) < 10 and len(threads) > 0:

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -17,6 +17,7 @@ from models.batch import Batch
 from appliance_cli.text import display_table
 
 from greenlet import greenlet
+import threading
 
 def add_commands(appliance):
 
@@ -218,9 +219,17 @@ def add_commands(appliance):
             def __init__(self, node, batch):
                 self.node = node
                 self.batch = batch
+                self.thread = threading.Thread(target=self.run)
 
             def green(self):
-                return greenlet(self.run)
+                return greenlet(self.run_greenlet)
+
+            # This method acts as the run method for greenlet. It is responsible for starting
+            # the job in a new thread
+            def run_greenlet(self):
+                # The thread identifier can be used to check if the thread has been started
+                if self.thread.ident is None: self.thread.start()
+                self.thread.join()
 
             def run(self):
                 local_session = Session()

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -240,8 +240,8 @@ def add_commands(appliance):
                 session.add(batch)
                 session.commit()
                 click.echo('Batch: {}\nExecuting: {}'.format(batch.id, batch.__name__()))
-                for node in nodes:
-                    JobRunner(node, batch).run()
+                job_greens = map(lambda n: greenlet(JobRunner(n, batch).run), nodes)
+                for green in job_greens: green.switch()
         finally:
             session.commit()
             session.close()

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -221,9 +221,14 @@ def add_commands(appliance):
                 session.commit()
                 output = output + 'Batch: {}\nExecuting: {}'.format(batch.id, batch.__name__())
                 for node in nodes:
-                    job = Job(node = node, batch = batch)
-                    session.add(job)
-                    job.run()
+                    local_session = Session()
+                    local_batch = local_session.merge(batch)
+                    job = Job(node = node, batch = local_batch)
+                    local_session.add(job)
+                    try:
+                        job.run()
+                    finally:
+                        local_session.commit()
                     if job.exit_code == 0:
                         symbol = 'Pass'
                     else:

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -219,6 +219,9 @@ def add_commands(appliance):
                 self.node = node
                 self.batch = batch
 
+            def green(self):
+                return greenlet(self.run)
+
             def run(self):
                 local_session = Session()
                 local_batch = local_session.merge(self.batch)
@@ -240,7 +243,7 @@ def add_commands(appliance):
                 session.add(batch)
                 session.commit()
                 click.echo('Batch: {}\nExecuting: {}'.format(batch.id, batch.__name__()))
-                job_greens = map(lambda n: greenlet(JobRunner(n, batch).run), nodes)
+                job_greens = map(lambda n: JobRunner(n, batch).green(), nodes)
                 for green in job_greens: green.switch()
         finally:
             session.commit()

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -233,18 +233,19 @@ def add_commands(appliance):
 
             def run(self):
                 local_session = Session()
-                local_batch = local_session.merge(self.batch)
-                job = Job(node = self.node, batch = local_batch)
-                local_session.add(job)
                 try:
+                    local_batch = local_session.merge(self.batch)
+                    job = Job(node = self.node, batch = local_batch)
+                    local_session.add(job)
                     job.run()
+                    if job.exit_code == 0:
+                        symbol = 'Pass'
+                    else:
+                        symbol = 'Failed: {}'.format(job.exit_code)
+                    click.echo('{}: {}'.format(job.node, symbol))
                 finally:
                     local_session.commit()
-                if job.exit_code == 0:
-                    symbol = 'Pass'
-                else:
-                    symbol = 'Failed: {}'.format(job.exit_code)
-                click.echo('{}: {}'.format(job.node, symbol))
+                    Session.remove()
 
         session = Session()
         try:
@@ -256,5 +257,5 @@ def add_commands(appliance):
                 for green in job_greens: green.switch()
         finally:
             session.commit()
-            session.close()
+            Session.remove()
 

--- a/src/commands/batch.py
+++ b/src/commands/batch.py
@@ -213,13 +213,11 @@ def add_commands(appliance):
 
     def execute_batch(batches, nodes):
         session = Session()
-        output = ''
         try:
             for batch in batches:
-                if output: output = output + '\n'
                 session.add(batch)
                 session.commit()
-                output = output + 'Batch: {}\nExecuting: {}'.format(batch.id, batch.__name__())
+                click.echo('Batch: {}\nExecuting: {}'.format(batch.id, batch.__name__()))
                 for node in nodes:
                     local_session = Session()
                     local_batch = local_session.merge(batch)
@@ -233,9 +231,8 @@ def add_commands(appliance):
                         symbol = 'Pass'
                     else:
                         symbol = 'Failed: {}'.format(job.exit_code)
-                    output = output + '\n{}: {}'.format(job.node, symbol)
+                    click.echo('{}: {}'.format(job.node, symbol))
         finally:
             session.commit()
             session.close()
-            click.echo_via_pager(output)
 

--- a/src/database.py
+++ b/src/database.py
@@ -4,8 +4,10 @@ import config
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import scoped_session
 
 engine = create_engine('sqlite:///{}database.db'.format(config.LEADER))
-Session = sessionmaker(bind=engine)
+session_factory = sessionmaker(bind=engine)
+Session = scoped_session(session_factory)
 
 Base = declarative_base()


### PR DESCRIPTION
Previously all the jobs where run in series and thus greatly slowed down the batches. Instead each job will now be ran in a separate thread. This means both the `ssh` connection and `db` session is now concurrent.

Care needed to be taken to ensure all `db` objects and sessions are created/used/closed within the same thread. Sharing objects between threads is not possible unless they are correctly merged across. Also `scoped_session` are required to ensure each thread has its own db session. 