### PR TITLE
Use relative paths in the starter scripts

### DIFF
--- a/bin/production-starter
+++ b/bin/production-starter
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-CLI_DIR=/opt/adminware/cli
+CLI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 (cd "$CLI_DIR" && bin/starter "$@")

--- a/bin/sandbox-starter
+++ b/bin/sandbox-starter
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-CLI_DIR=/opt/adminware/cli
+CLI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 (cd "$CLI_DIR" && bin/starter sandbox)


### PR DESCRIPTION
Previously the path was hard coded, preventing it from being moved.
Instead the path should be inferred from the BASH_SOURCE

Fixes #111