### PR TITLE
Adapt `job view` into the `view result` command

### DIFF
--- a/src/commands/job.py
+++ b/src/commands/job.py
@@ -118,26 +118,3 @@ def add_commands(appliance):
             return rows
         display_table(headers, table_rows())
 
-    @job.command(help='Inspect a previous job')
-    @click.argument('batch_id', type=int)
-    @click.argument('node')
-    def view(batch_id, node):
-        session = Session()
-        job = session.query(Job) \
-                     .filter(Job.node == node) \
-                     .join(Job, Batch.jobs) \
-                     .filter(Batch.id == int(batch_id)) \
-                     .first()
-        if job == None: raise ClickException('No job found')
-        table_data = [
-            ['Date', job.created_date],
-            ['Batch ID', job.batch.id],
-            ['Node', job.node],
-            ['Exit Code', job.exit_code],
-            ['Command', job.batch.__name__()],
-            ['Arguments', job.batch.arguments],
-            ['STDOUT', job.stdout],
-            ['STDERR', job.stderr]
-        ]
-        display_table([], table_data)
-

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -32,7 +32,7 @@ def add_commands(appliance):
         if job == None: raise ClickException('No job found')
         table_data = [
             ['Date', job.created_date],
-            ['Batch ID', job.batch.id],
+            ['Job ID', job.id],
             ['Node', job.node],
             ['Exit Code', job.exit_code],
             ['Command', job.batch.__name__()],

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -29,7 +29,7 @@ def add_commands(appliance):
     @click.argument('job_id', type=int)
     def result(job_id):
         job = Session().query(Job).get(job_id)
-        if job == None: raise ClickException('No job found')
+        if job == None: raise click.ClickException('No job found')
         table_data = [
             ['Date', job.created_date],
             ['Job ID', job.id],

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -1,10 +1,15 @@
 
 import groups as groups_util
 
+from appliance_cli.text import display_table
+
 import click
 import click_tools
 import explore_tools
 from os.path import basename, join
+
+from database import Session
+from models.job import Job
 
 def add_commands(appliance):
     @appliance.group(help='View the available tools')
@@ -19,6 +24,23 @@ def add_commands(appliance):
     @click.argument('group_name')
     def group(group_name):
         click.echo_via_pager("\n".join(groups_util.nodes_in(group_name)))
+
+    @view.command(help='View the result from a previous job')
+    @click.argument('job_id', type=int)
+    def result(job_id):
+        job = Session().query(Job).get(job_id)
+        if job == None: raise ClickException('No job found')
+        table_data = [
+            ['Date', job.created_date],
+            ['Batch ID', job.batch.id],
+            ['Node', job.node],
+            ['Exit Code', job.exit_code],
+            ['Command', job.batch.__name__()],
+            ['Arguments', job.batch.arguments],
+            ['STDOUT', job.stdout],
+            ['STDERR', job.stderr]
+        ]
+        display_table([], table_data)
 
     @view.command(help='List available tools at a namespace')
     @click.argument('namespace', required=False)


### PR DESCRIPTION
Based on #118 

The `view result` command is similar to the original `job view` command in output. The main difference is `view result` takes the `job id` as a single input.

This is part of a greater effort to hide the `batch id` from the end user. Instead the `Batch` object will be used as an internal DB tool only. Part of #115, fixes #106 