### PR TITLE
Remove reference to Batch ID in `run tool`

### DIFF
--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -99,7 +99,7 @@ def add_commands(appliance):
             for batch in batches:
                 session.add(batch)
                 session.commit()
-                click.echo('Batch: {}\nExecuting: {}'.format(batch.id, batch.__name__()))
+                click.echo('Executing: {}'.format(batch.__name__()))
                 threads = list(map(lambda n: JobRunner(n, batch).thread, nodes))
                 threads.reverse()
                 active_threads = []

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -81,15 +81,16 @@ def add_commands(appliance):
                 local_session = Session()
                 try:
                     job = local_session.merge(self.unsafe_job)
-                    local_session.commit()
                     job.run()
+                    local_session.commit()
                     if job.exit_code == 0:
                         symbol = 'Pass'
                     else:
                         symbol = 'Failed: {}'.format(job.exit_code)
                     click.echo('ID: {}, Node: {}, {}'.format(job.id, job.node, symbol))
-                finally:
+                except:
                     local_session.commit()
+                finally:
                     Session.remove()
 
         session = Session()

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -104,7 +104,7 @@ def add_commands(appliance):
                 threads.reverse()
                 active_threads = []
                 while len(threads) > 0 or len(active_threads) > 0:
-                    while len(active_threads) < 5 and len(threads) > 0:
+                    while len(active_threads) < 10 and len(threads) > 0:
                         new_thread = threads.pop()
                         new_thread.start()
                         active_threads.append(new_thread)


### PR DESCRIPTION
Based on #119 

This PR removes references to `Batch ID` from the run command. Instead the `Job ID` that is unique to each node/command combo is printed. This did require updating when the `Job` is saved to the db in order to retrieve an ID.

This is the major change required to remove references to `Batch ID`. There are a few remaining cases where it is mentioned within the old `job` command. These will be removed when those commands are ported.

Otherwise this PR fixes #115 