### PR TITLE
Dev/node status

### DIFF
--- a/src/commands/job.py
+++ b/src/commands/job.py
@@ -20,43 +20,6 @@ def add_commands(appliance):
     def job():
         pass
 
-    @job.command(name='node-log', help="View the history of execution on a node")
-    @click.argument('node', type=str)
-    # note: this works on config location, not command name.
-    # Any commands that are moved will be considered distinct.
-    def node_log(node):
-        session = Session()
-        # returns 2-length tuples of the Job data and the amount of times the command's been run on <node>
-        job_query = session.query(Job, func.count(Batch.config))\
-                           .filter(Job.node == node)\
-                           .join("batch")\
-                           .order_by(Job.created_date.desc())\
-                           .group_by(Batch.config)\
-                           .all()
-        if not job_query: raise ClickException('No jobs found for node {}'.format(node))
-        headers = ['Command',
-                   'Exit Code',
-                   'Batch',
-                   'Arguments',
-                   'Date',
-                   'No. Runs']
-
-        rows = []
-        for command in job_query:
-            count = command[1]
-            command = command[0]
-            arguments = None if not command.batch.arguments else command.batch.arguments
-            row = [command.batch.__name__(),
-                   command.exit_code,
-                   command.batch.id,
-                   arguments,
-                   command.created_date,
-                   count]
-            rows += [row]
-            # sort by command name
-            rows.sort(key=lambda x:x[0])
-        display_table(headers, rows)
-
     @job.command(help='Retrieves recently ran jobs')
     @click.option('--limit', '-l', default=10, type=int, metavar='NUM',
                   help='Return the last NUM batches')

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -85,13 +85,13 @@ def add_commands(appliance):
     def node_status(node):
         session = Session()
         # returns 2-length tuples of the Job data and the amount of times the command's been run on <node>
-        job_query = session.query(Job, func.count(Batch.config))\
+        tool_data = session.query(Job, func.count(Batch.config))\
                            .filter(Job.node == node)\
                            .join("batch")\
                            .order_by(Job.created_date.desc())\
                            .group_by(Batch.config)\
                            .all()
-        if not job_query: raise ClickException('No jobs found for node {}'.format(node))
+        if not tool_data: raise ClickException('No jobs found for node {}'.format(node))
         headers = ['Command',
                    'Exit Code',
                    'Job ID',
@@ -99,7 +99,7 @@ def add_commands(appliance):
                    'Date',
                    'No. Runs']
         rows = []
-        for job, count in job_query:
+        for job, count in tool_data:
             arguments = None if not job.batch.arguments else job.batch.arguments
             row = [job.batch.__name__(),
                    job.exit_code,

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -84,7 +84,10 @@ def add_commands(appliance):
     # Any commands that are moved will be considered distinct.
     def node_status(node):
         session = Session()
-        # returns 2-length tuples of the Job data and the amount of times the command's been run on <node>
+        # Returns the most recent job for each tool and number of times it's been ran
+        # Refs: https://docs.sqlalchemy.org/en/latest/core/functions.html#sqlalchemy.sql.functions.count
+        #       https://www.w3schools.com/sql/func_sqlserver_count.asp
+        # => [(latest_job1, count1), (lastest_job2, count2), ...]
         tool_data = session.query(Job, func.count(Batch.config))\
                            .filter(Job.node == node)\
                            .join("batch")\

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -1,13 +1,15 @@
 
+import click_tools
+import explore_tools
 import groups as groups_util
 
 from appliance_cli.text import display_table
+from models.batch import Batch
 
 import click
-import click_tools
-import explore_tools
-from os.path import basename, join
 
+from os.path import basename, join
+from sqlalchemy import func
 from database import Session
 from models.job import Job
 
@@ -77,7 +79,7 @@ def add_commands(appliance):
         click.echo_via_pager(output)
 
     @view.command(name='node-status', help='View the execution history of a single node')
-    click.argument('node', type=str)
+    @click.argument('node', type=str)
     # note: this works on config location, not command name.
     # Any commands that are moved will be considered distinct.
     def node_status(node):
@@ -92,11 +94,10 @@ def add_commands(appliance):
         if not job_query: raise ClickException('No jobs found for node {}'.format(node))
         headers = ['Command',
                    'Exit Code',
-                   'Batch',
+                   'Job ID',
                    'Arguments',
                    'Date',
                    'No. Runs']
-
         rows = []
         for command in job_query:
             count = command[1]
@@ -104,7 +105,7 @@ def add_commands(appliance):
             arguments = None if not command.batch.arguments else command.batch.arguments
             row = [command.batch.__name__(),
                    command.exit_code,
-                   command.batch.id,
+                   command.id,
                    arguments,
                    command.created_date,
                    count]

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -99,15 +99,13 @@ def add_commands(appliance):
                    'Date',
                    'No. Runs']
         rows = []
-        for command in job_query:
-            count = command[1]
-            command = command[0]
-            arguments = None if not command.batch.arguments else command.batch.arguments
-            row = [command.batch.__name__(),
-                   command.exit_code,
-                   command.id,
+        for job, count in job_query:
+            arguments = None if not job.batch.arguments else job.batch.arguments
+            row = [job.batch.__name__(),
+                   job.exit_code,
+                   job.id,
                    arguments,
-                   command.created_date,
+                   job.created_date,
                    count]
             rows += [row]
             # sort by command name


### PR DESCRIPTION
Based off #120 (fix/remove-public-batch)

Moves `node_log` from `job` to `view`

Renames it to `node-status`

Changes output to use `job_ID` instead of `batch ID` as part of #115 