### PR TITLE
Implement the `view tool` command

### DIFF
--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -52,6 +52,7 @@ def add_commands(appliance):
             ['Name', config.name()],
             ['Description', config.help()],
             ['Shell Command', config.command()],
+            ['Families', '\n'.join(config.families())],
             ['Working Directory', '\n'.join(config.working_files())]
         ]
         display_table([], table_data)

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -11,9 +11,6 @@ from os.path import basename, join
 from database import Session
 from models.job import Job
 
-import subprocess
-from os.path import dirname
-
 def add_commands(appliance):
     @appliance.group(help='View the available tools')
     def view():
@@ -51,15 +48,11 @@ def add_commands(appliance):
 
     @click_tools.command(tool)
     def get_tool_info(config, _a):
-        ls_cmd = 'ls {}'.format(dirname(config.path))
-        stdout, _err = subprocess.Popen(ls_cmd, stdout=subprocess.PIPE, shell=True)\
-                                 .communicate()
-        working_files = stdout.decode("utf-8").rstrip('\n').split('\n')
         table_data = [
             ['Name', config.name()],
             ['Description', config.help()],
             ['Shell Command', config.command()],
-            ['Working Directory', '\n'.join(map(lambda f: "./{}".format(f), working_files))]
+            ['Working Directory', '\n'.join(config.working_files())]
         ]
         display_table([], table_data)
 

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -11,6 +11,9 @@ from os.path import basename, join
 from database import Session
 from models.job import Job
 
+import subprocess
+from os.path import dirname
+
 def add_commands(appliance):
     @appliance.group(help='View the available tools')
     def view():
@@ -39,6 +42,24 @@ def add_commands(appliance):
             ['Arguments', job.batch.arguments],
             ['STDOUT', job.stdout],
             ['STDERR', job.stderr]
+        ]
+        display_table([], table_data)
+
+    @view.group(help="View a tool's details")
+    def tool():
+        pass
+
+    @click_tools.command(tool)
+    def get_tool_info(config, _a):
+        ls_cmd = 'ls {}'.format(dirname(config.path))
+        stdout, _err = subprocess.Popen(ls_cmd, stdout=subprocess.PIPE, shell=True)\
+                                 .communicate()
+        working_files = stdout.decode("utf-8").rstrip('\n').split('\n')
+        table_data = [
+            ['Name', config.name()],
+            ['Description', config.help()],
+            ['Shell Command', config.command()],
+            ['Working Directory', '\n'.join(map(lambda f: "./{}".format(f), working_files))]
         ]
         display_table([], table_data)
 

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -52,6 +52,7 @@ def add_commands(appliance):
             ['Name', config.name()],
             ['Description', config.help()],
             ['Shell Command', config.command()],
+            ['Interactive', 'Yes' if config.interactive_only() else 'No'],
             ['Families', '\n'.join(config.families())],
             ['Working Directory', '\n'.join(config.working_files())]
         ]

--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,7 @@
 import appliance_cli.config
 import appliance_cli.text as text
 
-from os.path import join
+import os.path
 
 
 # Create Adminware CLI config object.
@@ -20,5 +20,7 @@ LEADER = '/var/lib/adminware/'
 
 TOOL_LOCATION = 'tools/'
 
+TOOL_DIR = os.path.join(LEADER, TOOL_LOCATION).strip('/')
+
 def join_with_tool_location(namespace):
-    return join(LEADER, TOOL_LOCATION, namespace)
+    return os.path.join(LEADER, TOOL_LOCATION, namespace)

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1,6 +1,7 @@
 import yaml
 import re
 from os.path import basename, dirname
+import subprocess
 
 from config import LEADER, TOOL_LOCATION
 
@@ -49,3 +50,11 @@ class Config():
 
     def command_exists(self):
         return 'command' in self.data and self.data['command']
+
+    def working_files(self):
+        ls_cmd = 'ls {}'.format(dirname(self.path))
+        stdout, _err = subprocess.Popen(ls_cmd, stdout=subprocess.PIPE, shell=True)\
+                                 .communicate()
+        working_files = stdout.decode("utf-8").rstrip('\n').split('\n')
+        return list(map(lambda f: "./{}".format(f), working_files))
+

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -3,7 +3,7 @@ import re
 from os.path import basename, dirname
 import subprocess
 
-from config import LEADER, TOOL_LOCATION
+from config import TOOL_DIR
 
 class Config():
     def __init__(self, path):
@@ -17,15 +17,16 @@ class Config():
         return basename(dirname(self.path))
 
     def name(self):
-        return "{} {}".format(self.additional_namespace(), self.__name__())
+        prefix = (self.additional_namespace() + ' ' if self.additional_namespace() else '')
+        return "{}{}".format(prefix, self.__name__())
 
     # to capture everything after /var/lib/adminware/tools/{batch, open} but before the command's name
     def additional_namespace(self):
         top_path = dirname(dirname(self.path))
-        regex_expr = re.escape(LEADER + TOOL_LOCATION) + r'.*?(\/.*?$)'
-        match = re.search(regex_expr, top_path)
-        if match: match =  match.group(1)
-        return match
+        regex_expr = re.escape(TOOL_DIR) + r'(\/.*?$)'
+        result = re.search(regex_expr, top_path)
+        namespace_path = result.group(1) if result else ''
+        return namespace_path.translate(namespace_path.maketrans('/', ' ')).strip()
 
     def command(self):
         default = 'MISSING: Command for {}'.format(self.__name__())

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -20,7 +20,6 @@ class Config():
         prefix = (self.additional_namespace() + ' ' if self.additional_namespace() else '')
         return "{}{}".format(prefix, self.__name__())
 
-    # to capture everything after /var/lib/adminware/tools/{batch, open} but before the command's name
     def additional_namespace(self):
         top_path = dirname(dirname(self.path))
         regex_expr = re.escape(TOOL_DIR) + r'(\/.*?$)'

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -15,6 +15,9 @@ class Config():
     def __name__(self):
         return basename(dirname(self.path))
 
+    def name(self):
+        return "{} {}".format(self.additional_namespace(), self.__name__())
+
     # to capture everything after /var/lib/adminware/tools/{batch, open} but before the command's name
     def additional_namespace(self):
         top_path = dirname(dirname(self.path))


### PR DESCRIPTION
The `view tool` command acts as a front end to what is stored within the `config,yaml` it also prints outs the command name based on the `tool's` file path. Finally it works out which files will be `scp` based on the `tool's` directory.

This did require updating how `additional_namespace` works as it had a bug in it (see https://github.com/alces-software/adminware/commit/3b97d6318c802d88b545d9e6046a50a8052f78a3). This PR also implements a proper `Config.name` method that combines the tool "__name__" and namespaces