### PR TITLE
Feat/tool status

### DIFF
--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -139,8 +139,8 @@ def add_commands(appliance):
         if not node_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
         headers, rows = gen_columns(node_data)
         headers = ['Node'] + headers
-        for i, node_datum in enumerate(node_data):
-            rows[i] = [node_datum[0].node] + rows[i]
+        for i, (job, _c) in enumerate(node_data):
+            rows[i] = [job.node] + rows[i]
         # sort by first column
         rows.sort(key=lambda x:x[0])
         display_table(headers, rows)

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -112,7 +112,7 @@ def add_commands(appliance):
                            .group_by(Batch.config)\
                            .all()
         if not tool_data: raise ClickException('No jobs found for node {}'.format(node))
-        headers, rows = gen_columns(tool_data)
+        headers, rows = shared_job_data_table(tool_data)
         headers = ['Tool'] + headers
         for i, tool_datum in enumerate(tool_data):
             rows[i] = [tool_datum[0].batch.__name__()] + rows[i]
@@ -137,7 +137,7 @@ def add_commands(appliance):
                            .group_by(Job.node)\
                            .all()
         if not job_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
-        headers, rows = gen_columns(job_data)
+        headers, rows = shared_job_data_table(job_data)
         headers = ['Node'] + headers
         for i, (job, _) in enumerate(job_data):
             rows[i] = [job.node] + rows[i]
@@ -145,7 +145,7 @@ def add_commands(appliance):
         rows.sort(key=lambda x:x[0])
         display_table(headers, rows)
 
-    def gen_columns(data):
+    def shared_job_data_table(data):
         headers = ['Exit Code',
                     'Job ID',
                     'Arguments',

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -137,7 +137,7 @@ def add_commands(appliance):
         pass
 
     @click_tools.command(tool_status, exclude_interactive_only = True)
-    def tool_status_runner(config, arguments):
+    def tool_status_runner(config, _):
         session = Session()
         # Returns the most recent job for each node and the number of times the tool's been ran
         # Refs: https://docs.sqlalchemy.org/en/latest/core/functions.html#sqlalchemy.sql.functions.count

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -114,8 +114,8 @@ def add_commands(appliance):
         if not job_data: raise ClickException('No jobs found for node {}'.format(node))
         headers, rows = shared_job_data_table(job_data)
         headers = ['Tool'] + headers
-        for i, tool_datum in enumerate(job_data):
-            rows[i] = [tool_datum[0].batch.__name__()] + rows[i]
+        for i, (job, _) in enumerate(job_data):
+            rows[i] = [job.batch.__name__()] + rows[i]
         # sort by first column
         rows.sort(key=lambda x:x[0])
         display_table(headers, rows)

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -129,17 +129,17 @@ def add_commands(appliance):
         session = Session()
         # Returns the most recent job for each node and the number of times the tool's been ran
         # => [(latest_job1, count1), (lastest_job2, count2), ...]
-        node_data = session.query(Job, func.count(Job.node))\
+        job_data = session.query(Job, func.count(Job.node))\
                            .select_from(Batch)\
                            .filter(Batch.config == config.path)\
                            .join(Job.batch)\
                            .order_by(Job.created_date.desc())\
                            .group_by(Job.node)\
                            .all()
-        if not node_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
-        headers, rows = gen_columns(node_data)
+        if not job_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
+        headers, rows = gen_columns(job_data)
         headers = ['Node'] + headers
-        for i, (job, _c) in enumerate(node_data):
+        for i, (job, _) in enumerate(job_data):
             rows[i] = [job.node] + rows[i]
         # sort by first column
         rows.sort(key=lambda x:x[0])

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -105,16 +105,16 @@ def add_commands(appliance):
         # Refs: https://docs.sqlalchemy.org/en/latest/core/functions.html#sqlalchemy.sql.functions.count
         #       https://www.w3schools.com/sql/func_sqlserver_count.asp
         # => [(latest_job1, count1), (lastest_job2, count2), ...]
-        tool_data = session.query(Job, func.count(Batch.config))\
+        job_data = session.query(Job, func.count(Batch.config))\
                            .filter(Job.node == node)\
                            .join("batch")\
                            .order_by(Job.created_date.desc())\
                            .group_by(Batch.config)\
                            .all()
-        if not tool_data: raise ClickException('No jobs found for node {}'.format(node))
-        headers, rows = shared_job_data_table(tool_data)
+        if not job_data: raise ClickException('No jobs found for node {}'.format(node))
+        headers, rows = shared_job_data_table(job_data)
         headers = ['Tool'] + headers
-        for i, tool_datum in enumerate(tool_data):
+        for i, tool_datum in enumerate(job_data):
             rows[i] = [tool_datum[0].batch.__name__()] + rows[i]
         # sort by first column
         rows.sort(key=lambda x:x[0])

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -144,11 +144,12 @@ def add_commands(appliance):
         #       https://www.w3schools.com/sql/func_sqlserver_count.asp
         # => [(latest_job1, count1), (lastest_job2, count2), ...]
         node_data = session.query(Job, func.count(Job.node))\
-                            .join(Batch)\
-                            .filter(Batch.config == config.path)\
-                            .order_by(Job.created_date.desc())\
-                            .group_by(Job.node)\
-                            .all()
+                           .select_from(Batch)\
+                           .filter(Batch.config == config.path)\
+                           .join(Job.batch)\
+                           .order_by(Job.created_date.desc())\
+                           .group_by(Job.node)\
+                           .all()
         if not node_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
         headers = ['Node',
                    'Exit Code',

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -112,25 +112,7 @@ def add_commands(appliance):
                            .group_by(Batch.config)\
                            .all()
         if not tool_data: raise ClickException('No jobs found for node {}'.format(node))
-        headers = ['Command',
-                   'Exit Code',
-                   'Job ID',
-                   'Arguments',
-                   'Date',
-                   'No. Runs']
-        rows = []
-        for job, count in tool_data:
-            arguments = None if not job.batch.arguments else job.batch.arguments
-            row = [job.batch.__name__(),
-                   job.exit_code,
-                   job.id,
-                   arguments,
-                   job.created_date,
-                   count]
-            rows += [row]
-            # sort by command name
-            rows.sort(key=lambda x:x[0])
-        display_table(headers, rows)
+        display_status(tool_data, 'node')
 
     @view.group(name='tool-status', help='View the execution history of a single tool')
     def tool_status():
@@ -151,23 +133,28 @@ def add_commands(appliance):
                            .group_by(Job.node)\
                            .all()
         if not node_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
-        headers = ['Node',
-                   'Exit Code',
-                   'Job ID',
-                   'Arguments',
-                   'Date',
-                   'No. Runs']
+        display_status(node_data, 'tool')
+
+    def display_status(data, topic):
+        if topic == 'node': headers = ['Tool']
+        elif topic == 'tool': headers = ['Node']
+        headers += ['Exit Code',
+                    'Job ID',
+                    'Arguments',
+                    'Date',
+                    'No. Runs']
         rows = []
-        for job, count in node_data:
+        for job, count in data:
             arguments = None if not job.batch.arguments else job.batch.arguments
-            row = [job.node,
-                   job.exit_code,
-                   job.id,
-                   arguments,
-                   job.created_date,
-                   count]
+            if topic == 'node': row = [job.batch.__name__()]
+            elif topic == 'tool': row = [job.node]
+            row += [job.exit_code,
+                    job.id,
+                    arguments,
+                    job.created_date,
+                    count]
             rows += [row]
-            # sort by node name
+            # sort by first column
             rows.sort(key=lambda x:x[0])
         display_table(headers, rows)
 


### PR DESCRIPTION
Fixes #105 
Like node-status but for viewing recent history of a single tool on each node

One argument - TOOL - uses `click_tool.command` to generate auto-completion results
Example output:
```
adminware> view tool-status steve                                                       
╔════════════╦═══════════╦════════╦═══════════╦════════════════════════════╦══════════╗ 
║ Node       ║ Exit Code ║ Job ID ║ Arguments ║ Date                       ║ No. Runs ║ 
╠════════════╬═══════════╬════════╬═══════════╬════════════════════════════╬══════════╣ 
║ localhost  ║ None      ║ 152    ║ None      ║ 2018-10-31 15:22:14.357953 ║ 2        ║ 
╠════════════╬═══════════╬════════╬═══════════╬════════════════════════════╬══════════╣ 
║ test_node  ║ None      ║ 224    ║ dsadsa    ║ 2018-10-31 16:57:23.426179 ║ 6        ║ 
╠════════════╬═══════════╬════════╬═══════════╬════════════════════════════╬══════════╣ 
║ test_node2 ║ None      ║ 148    ║ None      ║ 2018-10-31 15:19:49.956878 ║ 4        ║ 
╚════════════╩═══════════╩════════╩═══════════╩════════════════════════════╩══════════╝ 
```