### PR TITLE
Preliminary improvements to `view tools`

### DIFF
--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -8,7 +8,7 @@ from models.batch import Batch
 
 import click
 
-from os.path import basename, join
+from os.path import basename
 from sqlalchemy import func
 from database import Session
 from models.job import Job
@@ -45,10 +45,11 @@ def add_commands(appliance):
         display_table([], table_data)
 
     @view.command(help='List available tools at a namespace')
-    @click.argument('namespace', required=False)
-    def tools(namespace):
-        if not namespace: namespace = ''
-        dir_contents = explore_tools.inspect_namespace(namespace)
+    @click.argument('namespaces', nargs=-1, required=False)
+    def tools(namespaces):
+        if not namespaces: namespaces = ''
+        namespace_path = '/'.join(namespaces)
+        dir_contents = explore_tools.inspect_namespace(namespace_path)
         if dir_contents['configs'] or dir_contents['dirs']:
             output = ''
             for config in dir_contents['configs']:
@@ -56,10 +57,11 @@ def add_commands(appliance):
                 if config.interactive_only(): output = output + "Only runnable interactively\n"
             for directory in dir_contents['dirs']:
                 directory = basename(basename(directory))
-                output += "\n{} -- see 'view tools {}'\n".format(directory, join(namespace, directory))
+                new_command_namespaces = ' '.join(tuple(namespaces) + (directory, ))
+                output += "\n{} -- see 'view tools {}'\n".format(directory, new_command_namespaces)
         else:
-            if namespace:
-                output = "No commands or subdirectories in '{}'".format(namespace)
+            if namespaces:
+                output = "No commands or subdirectories in '{}'".format('/'.join(namespaces))
             else:
                 output = "No commands found"
         click.echo_via_pager(output)

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -56,7 +56,7 @@ def add_commands(appliance):
                 if config.interactive_only(): output = output + "Only runnable interactively\n"
             for directory in dir_contents['dirs']:
                 directory = basename(directory)
-                output += "\n{} -- see 'avail tools {}'\n".format(basename(directory),
+                output += "\n{} -- see 'view tools {}'\n".format(basename(directory),
                                                                   join(namespace,
                                                                   basename(directory)))
         else:

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -61,9 +61,9 @@ def add_commands(appliance):
                 output += "\n{} -- see 'view tools {}'\n".format(directory, new_command_namespaces)
         else:
             if namespaces:
-                output = "No commands or subdirectories in '{}'".format('/'.join(namespaces))
+                output = "No tools or subdirectories in '{}'".format('/'.join(namespaces))
             else:
-                output = "No commands found"
+                output = "No tools found"
         click.echo_via_pager(output)
 
     @view.command(help='List all available tool families')
@@ -75,7 +75,7 @@ def add_commands(appliance):
                 output = output + "\n{}".format(family.name) + \
                          "\n{}\n".format(" --> ".join(list(map(lambda x: x.__name__(), family.get_members_configs()))))
         else:
-            output = "No command families have been configured"
+            output = "No tool families have been configured"
         click.echo_via_pager(output)
 
     @view.command(name='node-status', help='View the execution history of a single node')

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -55,10 +55,8 @@ def add_commands(appliance):
                 output = output + "\n{} -- {}\n".format(config.__name__(), config.help())
                 if config.interactive_only(): output = output + "Only runnable interactively\n"
             for directory in dir_contents['dirs']:
-                directory = basename(directory)
-                output += "\n{} -- see 'view tools {}'\n".format(basename(directory),
-                                                                  join(namespace,
-                                                                  basename(directory)))
+                directory = basename(basename(directory))
+                output += "\n{} -- see 'view tools {}'\n".format(directory, join(namespace, directory))
         else:
             if namespace:
                 output = "No commands or subdirectories in '{}'".format(namespace)

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -7,8 +7,8 @@ from appliance_cli.text import display_table
 from models.batch import Batch
 
 import click
+import os.path
 
-from os.path import basename
 from sqlalchemy import func
 from database import Session
 from models.job import Job
@@ -56,7 +56,7 @@ def add_commands(appliance):
                 output = output + "\n{} -- {}\n".format(config.__name__(), config.help())
                 if config.interactive_only(): output = output + "Only runnable interactively\n"
             for directory in dir_contents['dirs']:
-                directory = basename(basename(directory))
+                directory = os.path.basename(os.path.basename(directory))
                 new_command_namespaces = ' '.join(tuple(namespaces) + (directory, ))
                 output += "\n{} -- see 'view tools {}'\n".format(directory, new_command_namespaces)
         else:


### PR DESCRIPTION
Now uses space delimited strings for namespaces, as opposed to slash delimited, for consistency.
Fixes help text to say `view tools` not `avail tools` 
Changes 'command' for 'tool' in some places
Still doesn't use use click auto completion but that will be done after `click tools` has been remade