### PR TITLE
Stop the Jobs being double logged into the db

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,48 @@ cd adminware
 make setup
 ```
 
+# Error Codes
+
+The exit code for the remote command is saved within the database. The meaning
+of the exit code is determined by the underlining command and will range from
+0-255.
+
+All negative exit codes indicate an internal `Adminware` error. The exit code
+meanings are as follows:
+
+| Error Code | Description             |
+| ---------- | ----------------------- |
+| -1         | SSH Connection Error    |
+| -2         | General Error           |
+| -3         | Interactive Job         |
+| -4         | Abandoned Job Error     |
+
+## -1: SSH Connection Error
+An initial ssh connection could not be established with the node.
+
+NOTE: This error code will only be issued for handled errors. It is still
+possible for unhandled ssh errors to be issued a different error code.
+
+## -2: General Error
+An error has occurred that concerns the job. See the jobs `STDERR` for more
+details.
+
+## -3: Interactive Job
+The tool has been ran in an interactive shell. The `STDOUT`, `STDERR`, and
+exit code are not available. This does not mean the Job failed, instead its
+status is undetermined.
+
+## -4: Abandoned Job Error
+The job has been created and queue to be ran but has since been abandoned.
+This indicates the `Job` was never ran, but this can not been known for
+certain.
+
+Possible Causes:
+1. `Adminware` was sent an interrupt,
+2. An uncaught SSH connection error has occurred,
+3. The connection was lost to the `adminware` appliance, or
+4. An unexpected error occurred before the `Job` was started.
+
 # Adding Commands
 Commands can be added to `batch run` and `open` features. `batch` runs the 
 command over a single or group of nodes and stores results in a database.

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -82,15 +82,13 @@ def add_commands(appliance):
                 try:
                     job = local_session.merge(self.unsafe_job)
                     job.run()
-                    local_session.commit()
                     if job.exit_code == 0:
                         symbol = 'Pass'
                     else:
                         symbol = 'Failed: {}'.format(job.exit_code)
                     click.echo('ID: {}, Node: {}, {}'.format(job.id, job.node, symbol))
-                except:
-                    local_session.commit()
                 finally:
+                    local_session.commit()
                     Session.remove()
 
         session = Session()

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -96,10 +96,10 @@ def add_commands(appliance):
         session = Session()
         try:
             for batch in batches:
+                jobs = list(map(lambda n: Job(node = n, batch = batch), nodes))
                 session.add(batch)
                 session.commit()
                 click.echo('Executing: {}'.format(batch.__name__()))
-                jobs = list(map(lambda n: Job(node = n, batch = batch), nodes))
                 threads = list(map(lambda j: JobRunner(j).thread, jobs))
                 threads.reverse()
                 active_threads = []

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -37,7 +37,7 @@ available. Please see documentation for possible causes
                 if self.batch.command_exists():
                     func()
                 else:
-                    self.stderr = 'Incorrectly conifgured command'
+                    self.stderr = 'Incorrectly configured command'
                     self.exit_code = -2
             return wrapper
 

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -20,8 +20,13 @@ class Job(Base):
     node = Column(String)
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
     stdout = Column(String)
-    stderr = Column(String)
-    exit_code = Column(Integer)
+    stderr = Column(String, default = '''
+Internal Error: Abandoned Job Error
+
+This job was added to the queue before being abandoned. No further results are
+available. Please see documentation for possible causes
+'''.strip())
+    exit_code = Column(Integer, default=-4)
     batch_id = Column(Integer, ForeignKey('batches.id'))
     batch = relationship("Batch", backref="jobs")
 


### PR DESCRIPTION
Each `Job` was being logged twice to the `db`. This was because the `Job` objects where being made in a master thread and then merged into slave runner threads.

B/c the Jobs in the master thread did not have an `ID`, they where considered different objects. There is some degree of data sharing between the object pairs due to how `session.merge` works, however its behaviour can not be relied on.

Instead the master thread needs to save all the `Jobs`; which assigns them an ID. Thus the slave threads Job objects share this ID and preform an update instead of a create.

Also  a new `Abandoned Job Error` code (-4) has been added. All new jobs are created in this state by default. This is more useful to the end user then saving an empty record to the database.

Fixes #122 