### PR TITLE
Combine the `run tool` and `run interactive` commands

### DIFF
--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -30,8 +30,8 @@ def add_commands(appliance):
         nodes = ctx.obj['adminware']['nodes']
         batch = Batch(config = config.path, arguments = arguments)
         batch.build_jobs(*nodes)
-        if batch.is_interactive():
-            pass
+        if batch.is_interactive() and (len(batch.jobs) == 1):
+            batch.jobs[0].run()
         elif batch.jobs:
             execute_threaded_batches([batch])
         else:

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -32,7 +32,7 @@ def add_commands(appliance):
         batch.build_jobs(*nodes)
         if batch.is_interactive():
             pass
-        elif nodes:
+        elif batch.jobs:
             execute_threaded_batches([batch])
         else:
             raise ClickException('Please give either --node or --group')

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -41,7 +41,7 @@ def add_commands(appliance):
     def tool(ctx, **kwargs):
         set_nodes_context(ctx, **kwargs)
 
-    @click_tools.command(tool, exclude_interactive_only = True)
+    @click_tools.command(tool)
     @click.pass_context
     def runnner(ctx, config, arguments):
         nodes = ctx.obj['adminware']['nodes']

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -30,8 +30,15 @@ def add_commands(appliance):
         nodes = ctx.obj['adminware']['nodes']
         batch = Batch(config = config.path, arguments = arguments)
         batch.build_jobs(*nodes)
-        if batch.is_interactive() and (len(batch.jobs) == 1):
-            batch.jobs[0].run()
+        if batch.is_interactive():
+            if len(batch.jobs) == 1:
+                batch.jobs[0].run()
+            elif batch.jobs:
+                raise ClickException('''
+'{}' is an interactive command and can only be ran on a single node
+'''.strip())
+            else:
+                raise ClickException('Please specify a node with --node')
         elif batch.jobs:
             execute_threaded_batches([batch])
         else:

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -15,23 +15,6 @@ def add_commands(appliance):
     def run():
         pass
 
-    @run.group(help='Run a tool in an interactive shell')
-    @click.option('--node', '-n', help='The node to run on')
-    @click.pass_context
-    def interactive(ctx, **kwargs):
-        if not 'node' in kwargs or not kwargs['node']:
-            raise ClickException("Please specify a node")
-        ctx.obj = { 'adminware' : { 'node' : kwargs['node'] } }
-
-    @click_tools.command(interactive)
-    @click.pass_context
-    def interactive_runner(ctx, config, arguments):
-        batch = Batch(config = config.path, arguments = arguments)
-        job = Job(node = ctx.obj['adminware']['node'], batch = batch)
-        job.run(interactive = True)
-        # Display the error if adminware errors (e.g. failed ssh connection)
-        if job.exit_code < 0: raise ClickException(job.stderr)
-
     @run.group(help='Run a tool over a batch of nodes')
     @click.option('--node', '-n', multiple=True, metavar='NODE',
                   help='Runs the command on the node')

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -81,6 +81,7 @@ def add_commands(appliance):
                 session.add(batch)
                 session.commit()
                 click.echo('Executing: {}'.format(batch.__name__()))
+                jobs = batch.build_jobs(*nodes)
                 threads = list(map(lambda j: JobRunner(j).thread, jobs))
                 threads.reverse()
                 active_threads = []

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -28,10 +28,13 @@ def add_commands(appliance):
     @click.pass_context
     def runnner(ctx, config, arguments):
         nodes = ctx.obj['adminware']['nodes']
-        if not nodes:
-            raise ClickException('Please give either --node or --group')
         batch = Batch(config = config.path, arguments = arguments)
-        execute_threaded_batches([batch], nodes)
+        if batch.is_interactive():
+            pass
+        elif nodes:
+            execute_threaded_batches([batch], nodes)
+        else:
+            raise ClickException('Please give either --node or --group')
 
     @run.group(help='Run a family of commands on node(s) or group(s)')
     @click.option('--node', '-n', multiple=True, metavar='NODE',

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -30,8 +30,8 @@ def add_commands(appliance):
         nodes = ctx.obj['adminware']['nodes']
         if not nodes:
             raise ClickException('Please give either --node or --group')
-        batch = [Batch(config = config.path, arguments = arguments)]
-        execute_batches(batch, nodes)
+        batch = Batch(config = config.path, arguments = arguments)
+        execute_threaded_batches([batch], nodes)
 
     @run.group(help='Run a family of commands on node(s) or group(s)')
     @click.option('--node', '-n', multiple=True, metavar='NODE',
@@ -52,9 +52,9 @@ def add_commands(appliance):
         for config in command_configs:
             #create batch w/ relevant config for command
             batches += [Batch(config=config.path)]
-        execute_batches(batches, nodes)
+        execute_threaded_batches(batches, nodes)
 
-    def execute_batches(batches, nodes):
+    def execute_threaded_batches(batches, nodes):
         class JobRunner:
             def __init__(self, job):
                 self.unsafe_job = job # This Job object may not thread safe

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -32,7 +32,14 @@ def add_commands(appliance):
         batch.build_jobs(*nodes)
         if batch.is_interactive():
             if len(batch.jobs) == 1:
-                batch.jobs[0].run()
+                session = Session()
+                try:
+                    session.add(batch)
+                    session.add(batch.jobs[0])
+                    batch.jobs[0].run()
+                finally:
+                    session.commit()
+                    Session.remove()
             elif batch.jobs:
                 raise ClickException('''
 '{}' is an interactive command and can only be ran on a single node

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -19,6 +19,9 @@ class Batch(Base):
     def __name__(self):
         return self.config_model.__name__()
 
+    def name(self):
+        return self.config_model.name()
+
     def help(self):
         return self.config_model.help()
 

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, String, Integer, DateTime, orm
 
 from database import Base
 from models.config import Config
+from models.job import Job
 
 class Batch(Base):
     __tablename__ = 'batches'
@@ -29,6 +30,9 @@ class Batch(Base):
 
     def is_interactive(self):
         return self.config_model.interactive()
+
+    def build_jobs(self, *nodes):
+        return list(map(lambda n: Job(node = n, batch = self), nodes))
 
     def __init__(self, **kwargs):
         self.config = kwargs['config']

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -27,6 +27,9 @@ class Batch(Base):
     def command_exists(self):
         return self.config_model.command_exists()
 
+    def is_interactive(self):
+        return self.config_model.interactive()
+
     def __init__(self, **kwargs):
         self.config = kwargs['config']
         if 'arguments' in kwargs: self.arguments = ' '. join(kwargs['arguments'])

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -45,8 +45,12 @@ class Config():
         if not self.data['families']: self.data['families'] = default
         return self.data['families']
 
+    # Deprecated, avoid usage
     def interactive_only(self):
-        return 'interactive_only' in self.data and self.data['interactive_only'] == True
+        return self.interactive()
+
+    def interactive(self):
+        return 'interactive' in self.data and self.data['interactive'] == True
 
     def command_exists(self):
         return 'command' in self.data and self.data['command']

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -59,9 +59,14 @@ available. Please see documentation for possible causes
         @__with_connection
         def __runner(connection):
             def __set_result(result):
-                self.stdout = result.stdout
-                self.stderr = result.stderr
-                self.exit_code = result.return_code
+                if self.batch.is_interactive():
+                    self.stdout = 'Interactive Job: STDOUT is unavailable'
+                    self.stderr = 'Interactive Job: STDERR is unavailable'
+                    self.exit_code = -3
+                else:
+                    self.stdout = result.stdout
+                    self.stderr = result.stderr
+                    self.exit_code = result.return_code
 
             def __with_tempdir(func):
                 def wrapper(*args):

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -8,7 +8,6 @@ from shlex import quote
 from sqlalchemy import Column, String, Integer, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 
-from models.batch import Batch
 from database import Base
 
 
@@ -104,4 +103,6 @@ available. Please see documentation for possible causes
     def __init__(self, **kwargs):
         self.node = kwargs['node']
         self.batch = kwargs['batch']
+
+from models.batch import Batch
 

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -31,7 +31,7 @@ available. Please see documentation for possible causes
     batch = relationship("Batch", backref="jobs")
 
 
-    def run(self, interactive=False):
+    def run(self):
         def __check_command(func):
             def wrapper():
                 if self.batch.command_exists():
@@ -90,7 +90,7 @@ available. Please see documentation for possible causes
                 # Runs the command
                 with connection.cd(temp_dir):
                     kwargs = { 'warn' : True }
-                    if interactive:
+                    if self.batch.is_interactive():
                         kwargs.update({ 'pty': True })
                     else:
                         kwargs.update({ 'hide': 'both' })


### PR DESCRIPTION
Now that the `config` specifies if a tool is interactive, it is possible to collapse `run interactive` into `run tool`. A bit of logic is required to do this, as interactive commands can only be ran on a single node.

It also requires a separate running method as interactive commands should not be ran in threads and should skip reporting the results back.

Finally interactive commands are now logged to the `db` with exit code `-3` and stubbed STDOUT and STDERR.