### PR TITLE
Additional command changes to `run tool`

### DIFF
--- a/src/appliance_cli/command_generation.py
+++ b/src/appliance_cli/command_generation.py
@@ -159,8 +159,11 @@ def _form_arguments(arguments_config):
     args_map = OrderedDict()
     is_required = True
     for arg_name in arguments_config:
-        identifier = _parameter_identifier(arg_name)
-        args_map[identifier] = click.Argument([arg_name], required = is_required)
+        def add_argument(name):
+            identifier = _parameter_identifier(name)
+            args_map[identifier] = click.Argument([name], required = is_required)
+
+        add_argument(arg_name)
     return args_map
 
 

--- a/src/appliance_cli/command_generation.py
+++ b/src/appliance_cli/command_generation.py
@@ -158,12 +158,17 @@ def _parse_simple_command_config(ancestor_commands, config, callback):
 def _form_arguments(arguments_config):
     args_map = OrderedDict()
     is_required = True
-    for arg_name in arguments_config:
+    for arg_n in arguments_config:
         def add_argument(name):
             identifier = _parameter_identifier(name)
             args_map[identifier] = click.Argument([name], required = is_required)
 
-        add_argument(arg_name)
+        if isinstance(arg_n, list):
+            # Sublists flag all future arguments as optional
+            is_required = False
+            for n in arg_n: add_argument(n)
+        else:
+            add_argument(arg_name)
     return args_map
 
 

--- a/src/appliance_cli/command_generation.py
+++ b/src/appliance_cli/command_generation.py
@@ -157,9 +157,10 @@ def _parse_simple_command_config(ancestor_commands, config, callback):
 
 def _form_arguments(arguments_config):
     args_map = OrderedDict()
+    is_required = True
     for arg_name in arguments_config:
         identifier = _parameter_identifier(arg_name)
-        args_map[identifier] = click.Argument([arg_name])
+        args_map[identifier] = click.Argument([arg_name], required = is_required)
     return args_map
 
 

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -3,7 +3,13 @@ import groups
 from click import ClickException
 from collections import OrderedDict
 
-def nodes_in__node__group_opts(options):
+def with__node__group(cmd_func):
+    def __with__node__group(config, argv, options, *a):
+        nodes = nodes_in__node__group(options)
+        cmd_func(config, argv, options, nodes, *a)
+    return __with__node__group
+
+def nodes_in__node__group(options):
     nodes = groups.expand_nodes(options['node'].value)
     for group in options['group'].value:
         group_nodes = groups.nodes_in(group)

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -3,6 +3,8 @@ import groups
 from click import ClickException
 from collections import OrderedDict
 
+import re
+
 def with__node__group(cmd_func):
     def __with__node__group(config, argv, options, *a):
         nodes = nodes_in__node__group(options)
@@ -17,6 +19,16 @@ def nodes_in__node__group(options):
             raise ClickException('Could not find group: {}'.format(group))
         nodes.extend(group_nodes)
     return list(__remove_duplicates(nodes))
+
+def strip_escaped_argv(func):
+    def __strip_escaped_argv(c, argv, *a):
+        parsed = list(map(lambda a: strip(a), argv))
+        func(c, parsed, *a)
+
+    def strip(string):
+        return re.sub(r'^\\\s*', '', string)
+
+    return __strip_escaped_argv
 
 def set_nodes_context(ctx, **kwargs):
     # populate ctx.obj with nodes

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -22,11 +22,11 @@ def nodes_in__node__group(options):
 
 def strip_escaped_argv(func):
     def __strip_escaped_argv(c, argv, *a):
-        parsed = list(map(lambda a: strip(a), argv))
+        parsed = list(map(lambda arg: strip(arg), argv))
         func(c, parsed, *a)
 
     def strip(string):
-        return re.sub(r'^\\\s*', '', string)
+        return (re.sub(r'^\\\s*', '', string) if isinstance(string, str) else string)
 
     return __strip_escaped_argv
 

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -3,6 +3,15 @@ import groups
 from click import ClickException
 from collections import OrderedDict
 
+def nodes_in__node__group_opts(options):
+    nodes = groups.expand_nodes(options['node'].value)
+    for group in options['group'].value:
+        group_nodes = groups.nodes_in(group)
+        if not group_nodes:
+            raise ClickException('Could not find group: {}'.format(group))
+        nodes.extend(group_nodes)
+    return list(__remove_duplicates(nodes))
+
 def set_nodes_context(ctx, **kwargs):
     # populate ctx.obj with nodes
     obj = { 'nodes' : [] }

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -38,7 +38,7 @@ def add_commands(appliance):
         }
     }
     runner_group = {
-        'help': "TODO: I'll write this soon....."
+        'help': (lambda names: "Run further tools: '{}'".format(' '.join(names)))
     }
 
     @Config.commands(tool, command = runner_cmd, group = runner_group)

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -62,7 +62,8 @@ def add_commands(appliance):
     }
 
     @Config.commands(tool, command = runner_cmd)
-    def runner(config, argv, opt):
+    @cli_utils.with__node__group
+    def runner(config, argv, opt, nodes):
         print(cli_utils.nodes_in__node__group_opts(opt))
         print(config)
         print(argv)

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -13,7 +13,21 @@ from models.config import Config
 import threading
 
 config_hash = Config.hashify_all(
-        command = { 'help': Config.help }
+        command = {
+            'help': Config.help,
+            'options': {
+                ('--node', '-n'): {
+                    'help': 'Runs the command over the node',
+                    'multiple': True,
+                    'metavar': 'NODE'
+                },
+                ('--group', '-g'): {
+                    'help': 'Runs the command over the group',
+                    'multiple': True,
+                    'metavar': 'GROUP'
+                }
+            }
+        }
     )
 
 def add_commands(appliance):
@@ -22,38 +36,37 @@ def add_commands(appliance):
         pass
 
     @run.group(help='Run a tool over a batch of nodes')
-    @click.option('--node', '-n', multiple=True, metavar='NODE',
-                  help='Runs the command on the node')
-    @click.option('--group', '-g', multiple=True, metavar='GROUP',
-                  help='Runs the command over the group')
-    @click.pass_context
-    def tool(ctx, **kwargs):
-        set_nodes_context(ctx, **kwargs)
+    def tool():
+        pass
 
-    def runner(ctx, config, arguments):
-        nodes = ctx.obj['adminware']['nodes']
-        batch = Batch(config = config.path, arguments = arguments)
-        batch.build_jobs(*nodes)
-        if batch.is_interactive():
-            if len(batch.jobs) == 1:
-                session = Session()
-                try:
-                    session.add(batch)
-                    session.add(batch.jobs[0])
-                    batch.jobs[0].run()
-                finally:
-                    session.commit()
-                    Session.remove()
-            elif batch.jobs:
-                raise ClickException('''
-'{}' is an interactive command and can only be ran on a single node
-'''.strip())
-            else:
-                raise ClickException('Please specify a node with --node')
-        elif batch.jobs:
-            execute_threaded_batches([batch])
-        else:
-            raise ClickException('Please give either --node or --group')
+    # def runner(ctx, config, arguments):
+    #     nodes = ctx.obj['adminware']['nodes']
+    #     batch = Batch(config = config.path, arguments = arguments)
+    #     batch.build_jobs(*nodes)
+    #     if batch.is_interactive():
+    #         if len(batch.jobs) == 1:
+    #             session = Session()
+    #             try:
+    #                 session.add(batch)
+    #                 session.add(batch.jobs[0])
+    #                 batch.jobs[0].run()
+    #             finally:
+    #                 session.commit()
+    #                 Session.remove()
+    #         elif batch.jobs:
+    #             raise ClickException('''
+# '{}' is an interactive command and can only be ran on a single node
+# '''.strip())
+    #         else:
+    #             raise ClickException('Please specify a node with --node')
+    #     elif batch.jobs:
+    #         execute_threaded_batches([batch])
+    #     else:
+    #         raise ClickException('Please give either --node or --group')
+    def runner(callstack, argv, opt):
+        print(callstack)
+        print(argv)
+        print(opt)
     generate_commands(tool, config_hash, runner)
 
     @run.group(help='Run a family of commands on node(s) or group(s)')

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -13,7 +13,7 @@ from models.config import Config
 import threading
 
 config_hash = Config.hashify_all(
-        help = Config.help
+        command = { 'help': Config.help }
     )
 
 def add_commands(appliance):

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -61,8 +61,8 @@ def add_commands(appliance):
     }
 
     @Config.commands(tool, command = runner_cmd)
-    def runner(callstack, argv, opt):
-        print(callstack)
+    def runner(config, argv, opt):
+        print(config)
         print(argv)
         print(opt)
 

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -3,7 +3,6 @@ import click
 from click import ClickException
 import click_tools
 from cli_utils import set_nodes_context
-from appliance_cli.command_generation import generate_commands
 
 from database import Session
 from models.job import Job
@@ -11,24 +10,6 @@ from models.batch import Batch
 from models.config import Config
 
 import threading
-
-config_hash = Config.hashify_all(
-        command = {
-            'help': Config.help,
-            'options': {
-                ('--node', '-n'): {
-                    'help': 'Runs the command over the node',
-                    'multiple': True,
-                    'metavar': 'NODE'
-                },
-                ('--group', '-g'): {
-                    'help': 'Runs the command over the group',
-                    'multiple': True,
-                    'metavar': 'GROUP'
-                }
-            }
-        }
-    )
 
 def add_commands(appliance):
     @appliance.group(help='Run a tool within your cluster')
@@ -63,11 +44,27 @@ def add_commands(appliance):
     #         execute_threaded_batches([batch])
     #     else:
     #         raise ClickException('Please give either --node or --group')
+    runner_cmd = {
+        'help': Config.help,
+        'options': {
+            ('--node', '-n'): {
+                'help': 'Runs the command over the node',
+                'multiple': True,
+                'metavar': 'NODE'
+            },
+            ('--group', '-g'): {
+                'help': 'Runs the command over the group',
+                'multiple': True,
+                'metavar': 'GROUP'
+            }
+        }
+    }
+
+    @Config.commands(tool, command = runner_cmd)
     def runner(callstack, argv, opt):
         print(callstack)
         print(argv)
         print(opt)
-    generate_commands(tool, config_hash, runner)
 
     @run.group(help='Run a family of commands on node(s) or group(s)')
     @click.option('--node', '-n', multiple=True, metavar='NODE',

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -23,6 +23,7 @@ def add_commands(appliance):
 
     runner_cmd = {
         'help': Config.help,
+        'arguments': ['remote_arguments'],
         'options': {
             ('--node', '-n'): {
                 'help': 'Runs the command over the node',
@@ -39,9 +40,8 @@ def add_commands(appliance):
 
     @Config.commands(tool, command = runner_cmd)
     @cli_utils.with__node__group
-    def runner(config, _argv, _opt, nodes):
-        arguments = []
-        batch = Batch(config = config.path, arguments = [])
+    def runner(config, argv, _opt, nodes):
+        batch = Batch(config = config.path, arguments = argv[0])
         batch.build_jobs(*nodes)
         if batch.is_interactive():
             if len(batch.jobs) == 1:

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -39,6 +39,7 @@ def add_commands(appliance):
     }
 
     @Config.commands(tool, command = runner_cmd)
+    @cli_utils.strip_escaped_argv
     @cli_utils.with__node__group
     def runner(config, argv, _opt, nodes):
         batch = Batch(config = config.path, arguments = argv[0])

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -23,7 +23,7 @@ def add_commands(appliance):
 
     runner_cmd = {
         'help': Config.help,
-        'arguments': ['remote_arguments'],
+        'arguments': [['remote_arguments']], # [[]]: Optional Arg
         'options': {
             ('--node', '-n'): {
                 'help': 'Runs the command over the node',
@@ -45,7 +45,7 @@ def add_commands(appliance):
     @cli_utils.strip_escaped_argv
     @cli_utils.with__node__group
     def runner(config, argv, _, nodes):
-        batch = Batch(config = config.path, arguments = argv[0])
+        batch = Batch(config = config.path, arguments = (argv[0] or ''))
         batch.build_jobs(*nodes)
         if batch.is_interactive():
             if len(batch.jobs) == 1:

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -44,7 +44,7 @@ def add_commands(appliance):
     @Config.commands(tool, command = runner_cmd, group = runner_group)
     @cli_utils.strip_escaped_argv
     @cli_utils.with__node__group
-    def runner(config, argv, _opt, nodes):
+    def runner(config, argv, _, nodes):
         batch = Batch(config = config.path, arguments = argv[0])
         batch.build_jobs(*nodes)
         if batch.is_interactive():

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -3,6 +3,7 @@ import click
 from click import ClickException
 import click_tools
 from cli_utils import set_nodes_context
+import cli_utils
 
 from database import Session
 from models.job import Job
@@ -62,6 +63,7 @@ def add_commands(appliance):
 
     @Config.commands(tool, command = runner_cmd)
     def runner(config, argv, opt):
+        print(cli_utils.nodes_in__node__group_opts(opt))
         print(config)
         print(argv)
         print(opt)

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -37,8 +37,11 @@ def add_commands(appliance):
             }
         }
     }
+    runner_group = {
+        'help': "TODO: I'll write this soon....."
+    }
 
-    @Config.commands(tool, command = runner_cmd)
+    @Config.commands(tool, command = runner_cmd, group = runner_group)
     @cli_utils.strip_escaped_argv
     @cli_utils.with__node__group
     def runner(config, argv, _opt, nodes):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1,11 +1,21 @@
 import yaml
 import re
 from os.path import basename, dirname
+
+import os.path
+from glob import glob
+
 import subprocess
 
 from config import TOOL_DIR
 
+CONFIG_DIR = '/var/lib/adminware/tools'
+
 class Config():
+    def all():
+        glob_path = os.path.join(CONFIG_DIR, '**/*/config.yaml')
+        return list(map(lambda p: Config(p), glob(glob_path, recursive=True)))
+
     def __init__(self, path):
         self.path = path
         def __read_data():

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -52,11 +52,8 @@ class Config():
         for config in Config.all():
             base_hash = combined_hash
             for name in config.name().split():
-                if subcommand_key not in base_hash:
-                    base_hash[subcommand_key] = {}
-                cmd_hash = base_hash[subcommand_key]
-                if name not in cmd_hash: cmd_hash[name] = {}
-                base_hash = cmd_hash[name]
+                base_hash = base_hash.setdefault(subcommand_key, {})\
+                                     .setdefault(name, {})
             for k, v in command.items():
                 base_hash[k] = (v(config) if callable(v) else v)
         return combined_hash[subcommand_key]

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -7,7 +7,6 @@ from glob import glob
 
 import subprocess
 
-from config import TOOL_DIR
 from functools import lru_cache
 
 CONFIG_DIR = '/var/lib/adminware/tools'
@@ -36,7 +35,7 @@ class Config():
 
     def additional_namespace(self):
         top_path = dirname(dirname(self.path))
-        regex_expr = re.escape(TOOL_DIR) + r'(\/.*?$)'
+        regex_expr = re.escape(CONFIG_DIR) + r'(\/.*?$)'
         result = re.search(regex_expr, top_path)
         namespace_path = result.group(1) if result else ''
         return namespace_path.translate(namespace_path.maketrans('/', ' ')).strip()

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -19,16 +19,28 @@ class Config():
         glob_path = os.path.join(CONFIG_DIR, '**/*/config.yaml')
         return list(map(lambda p: Config(p), glob(glob_path, recursive=True)))
 
+    # The commands are hashed into the following structure
+    # NOTE: kwargs supports callable objects which takes the Config as its input
+    #       The result is then stored in the hash
+    #   {
+    #       command1: **kwargs,
+    #       namespace1: {
+    #           commands: {
+    #               command2: **kwargs
+    #           }
+    #   {
     def hashify_all(**kwargs):
         combined_hash = {}
         for config in Config.all():
             base_hash = combined_hash
             for name in config.name().split():
-                if name not in base_hash: base_hash[name] = {}
-                base_hash = base_hash[name]
+                if 'commands' not in base_hash: base_hash['commands'] = {}
+                cmd_hash = base_hash['commands']
+                if name not in cmd_hash: cmd_hash[name] = {}
+                base_hash = cmd_hash[name]
             for k, v in kwargs.items():
                 base_hash[k] = (v(config) if callable(v) else v)
-        return combined_hash
+        return combined_hash['commands']
 
     def __init__(self, path):
         self.path = path

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -61,7 +61,7 @@ class Config():
 
         cur_hash = combined_hash = {}
         for config in Config.all():
-            build_group_hashes()
+            cur_hash = build_group_hashes()
             copy_command_values()
 
         return combined_hash[subcommand_key]

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -55,11 +55,15 @@ class Config():
                                    .setdefault(name, {})
             return cur_hash
 
-        combined_hash = {}
-        for config in Config.all():
-            base_hash = build_group_hashes()
+        def copy_command_values():
             for k, v in command.items():
-                base_hash[k] = (v(config) if callable(v) else v)
+                cur_hash[k] = (v(config) if callable(v) else v)
+
+        cur_hash = combined_hash = {}
+        for config in Config.all():
+            build_group_hashes()
+            copy_command_values()
+
         return combined_hash[subcommand_key]
 
     def __init__(self, path):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -19,6 +19,17 @@ class Config():
         glob_path = os.path.join(CONFIG_DIR, '**/*/config.yaml')
         return list(map(lambda p: Config(p), glob(glob_path, recursive=True)))
 
+    def hashify_all(**kwargs):
+        combined_hash = {}
+        for config in Config.all():
+            base_hash = combined_hash
+            for name in config.name().split():
+                if name not in base_hash: base_hash[name] = {}
+                base_hash = base_hash[name]
+            for k, v in kwargs.items():
+                base_hash[k] = (v(config) if callable(v) else v)
+        return combined_hash
+
     def __init__(self, path):
         self.path = path
         def __read_data():

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -42,6 +42,7 @@ class Config():
     #   {
     #       command1: **<command>,
     #       namespace1: {
+    #           **<group>,
     #           <subcommand_key>: {
     #               command2: **<command>
     #               ...
@@ -52,18 +53,18 @@ class Config():
         def build_group_hashes():
             cur_hash = combined_hash
             for name in config.name().split():
+                copy_values(group, cur_hash)
                 cur_hash = cur_hash.setdefault(subcommand_key, {})\
                                    .setdefault(name, {})
             return cur_hash
 
-        def copy_values(source):
+        def copy_values(source, target):
             for k, v in source.items():
-                cur_hash[k] = (v(config) if callable(v) else v)
+                target[k] = (v(config) if callable(v) else v)
 
-        cur_hash = combined_hash = {}
+        combined_hash = {}
         for config in Config.all():
-            cur_hash = build_group_hashes()
-            copy_values(command)
+            copy_values(command, build_group_hashes())
 
         return combined_hash[subcommand_key]
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -52,19 +52,21 @@ class Config():
     def hashify_all(group = {}, command = {}, subcommand_key = ''):
         def build_group_hashes():
             cur_hash = combined_hash
-            for name in config.name().split():
-                copy_values(group, cur_hash)
+            name_parts = config.name().split()
+            for idx, name in enumerate(name_parts):
+                cur_names = name_parts[0:idx]
+                copy_values(group, cur_hash, cur_names)
                 cur_hash = cur_hash.setdefault(subcommand_key, {})\
                                    .setdefault(name, {})
             return cur_hash
 
-        def copy_values(source, target):
+        def copy_values(source, target, args):
             for k, v in source.items():
-                target[k] = (v(config) if callable(v) else v)
+                target[k] = (v(args) if callable(v) else v)
 
         combined_hash = {}
         for config in Config.all():
-            copy_values(command, build_group_hashes())
+            copy_values(command, build_group_hashes(), config)
 
         return combined_hash[subcommand_key]
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -5,6 +5,8 @@ from os.path import basename, dirname
 import os.path
 from glob import glob
 
+from appliance_cli.command_generation import generate_commands
+
 import subprocess
 
 from functools import lru_cache
@@ -12,6 +14,12 @@ from functools import lru_cache
 CONFIG_DIR = '/var/lib/adminware/tools'
 
 class Config():
+    def commands(root_command, **kwargs):
+        def __commands(callback):
+            config_hash = Config.hashify_all(subcommand_key = 'commands', **kwargs)
+            generate_commands(root_command, config_hash, callback)
+        return __commands
+
     # lru_cache will cache the result of the `all` function. This prevents the Config
     # files being read more than once. However it also prevents updates and creations
     @lru_cache()
@@ -30,7 +38,7 @@ class Config():
     #               ...
     #           }
     #   {
-    def hashify_all(group = {}, command = {}, subcommand_key = 'commands'):
+    def hashify_all(group = {}, command = {}, subcommand_key = ''):
         combined_hash = {}
         for config in Config.all():
             base_hash = combined_hash

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -15,8 +15,17 @@ CONFIG_DIR = '/var/lib/adminware/tools'
 
 class Config():
     def commands(root_command, **kwargs):
-        def __commands(callback):
+        class ConfigCallback():
+            def __init__(self, callback_func):
+                self.callback = callback_func
+
+            def run(self, callstack, *a):
+                path = os.path.join(CONFIG_DIR, *callstack, 'config.yaml')
+                self.callback(Config(path), *a)
+
+        def __commands(config_callback):
             config_hash = Config.hashify_all(subcommand_key = 'commands', **kwargs)
+            callback = ConfigCallback(config_callback).run
             generate_commands(root_command, config_hash, callback)
         return __commands
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -20,27 +20,28 @@ class Config():
         return list(map(lambda p: Config(p), glob(glob_path, recursive=True)))
 
     # The commands are hashed into the following structure
-    # NOTE: kwargs supports callable objects which takes the Config as its input
-    #       The result is then stored in the hash
+    # NOTE: `command` supports callable objects which takes the Config as its
+    #       input. The result is then stored in the hash
     #   {
-    #       command1: **kwargs,
+    #       command1: **<command>,
     #       namespace1: {
-    #           commands: {
-    #               command2: **kwargs
+    #           <subcommand_key>: {
+    #               command2: **<command>
     #           }
     #   {
-    def hashify_all(**kwargs):
+    def hashify_all(group = {}, command = {}, subcommand_key = 'commands'):
         combined_hash = {}
         for config in Config.all():
             base_hash = combined_hash
             for name in config.name().split():
-                if 'commands' not in base_hash: base_hash['commands'] = {}
-                cmd_hash = base_hash['commands']
+                if subcommand_key not in base_hash:
+                    base_hash[subcommand_key] = {}
+                cmd_hash = base_hash[subcommand_key]
                 if name not in cmd_hash: cmd_hash[name] = {}
                 base_hash = cmd_hash[name]
-            for k, v in kwargs.items():
+            for k, v in command.items():
                 base_hash[k] = (v(config) if callable(v) else v)
-        return combined_hash['commands']
+        return combined_hash[subcommand_key]
 
     def __init__(self, path):
         self.path = path

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -48,12 +48,16 @@ class Config():
     #           }
     #   {
     def hashify_all(group = {}, command = {}, subcommand_key = ''):
+        def build_group_hashes():
+            cur_hash = combined_hash
+            for name in config.name().split():
+                cur_hash = cur_hash.setdefault(subcommand_key, {})\
+                                   .setdefault(name, {})
+            return cur_hash
+
         combined_hash = {}
         for config in Config.all():
-            base_hash = combined_hash
-            for name in config.name().split():
-                base_hash = base_hash.setdefault(subcommand_key, {})\
-                                     .setdefault(name, {})
+            base_hash = build_group_hashes()
             for k, v in command.items():
                 base_hash[k] = (v(config) if callable(v) else v)
         return combined_hash[subcommand_key]

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -8,10 +8,14 @@ from glob import glob
 import subprocess
 
 from config import TOOL_DIR
+from functools import lru_cache
 
 CONFIG_DIR = '/var/lib/adminware/tools'
 
 class Config():
+    # lru_cache will cache the result of the `all` function. This prevents the Config
+    # files being read more than once. However it also prevents updates and creations
+    @lru_cache()
     def all():
         glob_path = os.path.join(CONFIG_DIR, '**/*/config.yaml')
         return list(map(lambda p: Config(p), glob(glob_path, recursive=True)))

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -27,6 +27,7 @@ class Config():
     #       namespace1: {
     #           <subcommand_key>: {
     #               command2: **<command>
+    #               ...
     #           }
     #   {
     def hashify_all(group = {}, command = {}, subcommand_key = 'commands'):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -46,7 +46,8 @@ class Config():
     #               command2: **<command>
     #               ...
     #           }
-    #   {
+    #       }
+    #   }
     def hashify_all(group = {}, command = {}, subcommand_key = ''):
         def build_group_hashes():
             cur_hash = combined_hash
@@ -55,14 +56,14 @@ class Config():
                                    .setdefault(name, {})
             return cur_hash
 
-        def copy_command_values():
-            for k, v in command.items():
+        def copy_values(source):
+            for k, v in source.items():
                 cur_hash[k] = (v(config) if callable(v) else v)
 
         cur_hash = combined_hash = {}
         for config in Config.all():
             cur_hash = build_group_hashes()
-            copy_command_values()
+            copy_values(command)
 
         return combined_hash[subcommand_key]
 


### PR DESCRIPTION
This PR expands on #133 and adds/fixes a few additional features:

1. It adds the `remote_arguments` back into the CLI, however the command syntax has changed to:
`run tool TOOL NAME <--node|--group> [REMOTE_ARGUMENTS]`
This has required modifying the `command_generation` code, which isn't ideally. This code has been duplicated from another repo. See #135

2. It sets the `click_group` help text again
3. Arguments to `run tool` can be escaped by starting the string with: `\`. This allows option flags to be passed through `click` without erroring. See #134 