### PR TITLE
Feat/history commands

### DIFF
--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -137,8 +137,10 @@ def add_commands(appliance):
     def tool_history():
         pass
 
-    @click_tools.command(tool_history, exclude_interactive_only = True)
-    def tool_history_runner(config, _):
+    tool_history_cmd = { 'help': 'List the history across the nodes' }
+    tool_history_grp = { 'help': 'See the history of further tools' }
+    @Config.commands(tool_history, command = tool_history_cmd, group = tool_history_grp)
+    def tool_history_runner(config, _a, _o):
         session = Session()
         job_data = session.query(Job)\
                           .select_from(Batch)\

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -153,7 +153,7 @@ def add_commands(appliance):
             rows[i] = [job.node] + rows[i]
         rows.sort(key=lambda x:x[1], reverse=True)
         display_table(headers, rows)
-        
+
     def shared_job_data_table(data):
         headers = ['Job ID',
                    'Exit Code',

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -10,7 +10,6 @@ from models.config import Config
 import click
 import os.path
 
-from click import ClickException
 from sqlalchemy import func
 from database import Session
 from models.job import Job
@@ -80,7 +79,7 @@ def add_commands(appliance):
                            .order_by(Job.created_date.desc())\
                            .group_by(Batch.config)\
                            .all()
-        if not job_data: raise ClickException('No jobs found for node {}'.format(node))
+        if not job_data: raise click.ClickException('No jobs found for node {}'.format(node))
         job_objects = [i for i, j in job_data]
         headers, rows = shared_job_data_table(job_objects)
         headers = ['Tool'] + headers + ['No. Runs']
@@ -108,7 +107,7 @@ def add_commands(appliance):
                            .order_by(Job.created_date.desc())\
                            .group_by(Job.node)\
                            .all()
-        if not job_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
+        if not job_data: raise click.ClickException('No jobs found for tool {}'.format(config.__name__()))
         job_objects = [i for i, j in job_data]
         headers, rows = shared_job_data_table(job_objects)
         headers = ['Node'] + headers + ['No. Runs']
@@ -126,7 +125,7 @@ def add_commands(appliance):
                           .filter(Job.node == node)\
                           .join("batch")\
                           .all()
-        if not job_data: raise ClickException('No jobs found for node {}'.format(node))
+        if not job_data: raise click.ClickException('No jobs found for node {}'.format(node))
         headers, rows = shared_job_data_table(job_data)
         headers = ['Tool'] + headers
         for i, job in enumerate(job_data):
@@ -146,7 +145,7 @@ def add_commands(appliance):
                           .filter(Batch.config == config.path)\
                           .join(Job.batch)\
                           .all()
-        if not job_data: raise ClickException('No jobs found for tool {}'.format(config.__name__()))
+        if not job_data: raise click.ClickException('No jobs found for tool {}'.format(config.__name__()))
         headers, rows = shared_job_data_table(job_data)
         headers = ['Node'] + headers
         for i, job in enumerate(job_data):


### PR DESCRIPTION
Implementation of `tool-history` and `node-history` commands. Take a tool or node respectively and displays all jobs ran for that tool/node. 

Currently suffers from the same issue outlined #128 - this isn't acceptable but is to be fixed in a later PR.

I've generalized further `shared_job_data_table` for the time being - to apply it for all history commands. This methodology will be removed completely before long.

It's possible that this entire methodology has been rendered incompatible by any of the PRs put up over the weekend (such as #133). I will put this up now anyway & investigate further.