### PR TITLE
Various "small" tweaks to adminware

### DIFF
--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -20,16 +20,6 @@ def nodes_in__node__group(options):
         nodes.extend(group_nodes)
     return list(__remove_duplicates(nodes))
 
-def strip_escaped_argv(func):
-    def __strip_escaped_argv(c, argv, *a):
-        parsed = list(map(lambda arg: strip(arg), argv))
-        func(c, parsed, *a)
-
-    def strip(string):
-        return (re.sub(r'^\\\s*', '', string) if isinstance(string, str) else string)
-
-    return __strip_escaped_argv
-
 def set_nodes_context(ctx, **kwargs):
     # populate ctx.obj with nodes
     obj = { 'nodes' : [] }

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -90,6 +90,9 @@ def add_commands(appliance):
         execute_threaded_batches(batches)
 
     def execute_threaded_batches(batches):
+        runners = []
+        active_runners = []
+
         class JobRunner:
             def __init__(self, job):
                 self.unsafe_job = job # This Job object may not thread safe
@@ -116,9 +119,8 @@ def add_commands(appliance):
                 session.add(batch)
                 session.commit()
                 click.echo('Executing: {}'.format(batch.__name__()))
-                runners = list(map(lambda j: JobRunner(j), batch.jobs))
+                runners += list(map(lambda j: JobRunner(j), batch.jobs))
                 runners.reverse()
-                active_runners = []
                 while len(runners) > 0 or len(active_runners) > 0:
                     while len(active_runners) < 10 and len(runners) > 0:
                         new_run = runners.pop()

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -98,6 +98,8 @@ def add_commands(appliance):
             print('Interrupt Received')
             # Stop all queued jobs from running
             runners.clear()
+            # Kills the `ssh` connections of the current threads
+            for r in active_runners: r.kill()
 
         class JobRunner:
             def __init__(self, job):

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -99,6 +99,9 @@ def add_commands(appliance):
                 self.thread = threading.Thread(target=self.run)
                 self.job = None
 
+            def kill(self):
+                if self.job: self.job.kill_connection_event.set()
+
             def run(self):
                 local_session = Session()
                 try:

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -42,7 +42,6 @@ def add_commands(appliance):
     }
 
     @Config.commands(tool, command = runner_cmd, group = runner_group)
-    @cli_utils.strip_escaped_argv
     @cli_utils.with__node__group
     def runner(config, argv, _, nodes):
         batch = Batch(config = config.path, arguments = (argv[0] or ''))

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -39,7 +39,7 @@ class Batch(Base):
 
     def __init__(self, **kwargs):
         self.config = kwargs['config']
-        if 'arguments' in kwargs: self.arguments = kwargs['arguments']
+        self.arguments = kwargs.setdefault('arguments')
         self.__init_or_load()
 
     @orm.reconstructor

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -39,7 +39,7 @@ class Batch(Base):
 
     def __init__(self, **kwargs):
         self.config = kwargs['config']
-        if 'arguments' in kwargs: self.arguments = ' '. join(kwargs['arguments'])
+        if 'arguments' in kwargs: self.arguments = kwargs['arguments']
         self.__init_or_load()
 
     @orm.reconstructor

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -59,7 +59,6 @@ available. Please see documentation for possible causes
                     self.exit_code = -1
                 if connection.is_connected:
                     try:
-                        self.kill_connection_event.clear()
                         worker = threading.Thread(target = run_function)
                         worker.start()
                         self.kill_connection_event.wait()


### PR DESCRIPTION
Turns out the buggy parsing of arguments was due to an `string` being passed in instead of an array. This meant the string was joined on spaces. This fixes #134. Also click supports `--` to separate arguments from options. So the `\` escaping has been removed.

Also the `interrupt` handling has been improved. It now stops all future Jobs from running and kills the `ssh` connection of current Jobs. This did require building a `ssh` connection kill switch using python `threading.Event` and even more threads 