### PR TITLE
Fix/tool not command

### DIFF
--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -58,7 +58,7 @@ def add_commands(appliance):
                     Session.remove()
             elif batch.jobs:
                 raise ClickException('''
-'{}' is an interactive command and can only be ran on a single node
+'{}' is an interactive tool and can only be ran on a single node
 '''.strip())
             else:
                 raise ClickException('Please specify a node with --node')
@@ -67,11 +67,11 @@ def add_commands(appliance):
         else:
             raise ClickException('Please give either --node or --group')
 
-    @run.group(help='Run a family of commands on node(s) or group(s)')
+    @run.group(help='Run a family of tools on node(s) or group(s)')
     def family(): pass
 
     family_runner = {
-        'help': 'Runs the command over the group',
+        'help': 'Runs the tool over the group',
         'options': node_group_options
     }
 
@@ -83,7 +83,7 @@ def add_commands(appliance):
             raise ClickException('Please give either --node or --group')
         batches = []
         for config in Config.all_families()[family]:
-            #create batch w/ relevant config for command
+            #create batch w/ relevant config for tool
             batch = Batch(config = config.path)
             batch.build_jobs(*nodes)
             batches += [batch]

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -38,7 +38,7 @@ def add_commands(appliance):
             ['Job ID', job.id],
             ['Node', job.node],
             ['Exit Code', job.exit_code],
-            ['Command', job.batch.__name__()],
+            ['Tool', job.batch.__name__()],
             ['Arguments', job.batch.arguments],
             ['STDOUT', job.stdout],
             ['STDERR', job.stderr]
@@ -77,8 +77,8 @@ def add_commands(appliance):
 
     @view.command(name='node-status', help='View the execution history of a single node')
     @click.argument('node', type=str)
-    # note: this works on config location, not command name.
-    # Any commands that are moved will be considered distinct.
+    # note: this works on tool location, not tool name.
+    # Any tools that are moved will be considered distinct.
     def node_status(node):
         session = Session()
         # Returns the most recent job for each tool and number of times it's been ran


### PR DESCRIPTION
Pretty self explanatory, where appropriate replaces `command` with `tool` in user-facing text (and some comments)

Fixes #116 