### PR TITLE
Dev/combine group and groups

### DIFF
--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -15,9 +15,8 @@ def with__node__group(cmd_func):
 def nodes_in__node__group(options):
     nodes = groups.expand_nodes(options['node'].value)
     for group in options['group'].value:
-        try:
-            group_nodes = Config.all_groups()[group]
-        except KeyError:
+        group_nodes = groups.nodes_in(group)
+        if not group_nodes:
             raise ClickException('Could not find group: {}'.format(group))
         nodes.extend(group_nodes)
     return list(__remove_duplicates(nodes))

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -1,6 +1,5 @@
 
 import groups
-from models.config import Config
 from click import ClickException
 from collections import OrderedDict
 

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -1,5 +1,6 @@
 
 import groups
+from models.config import Config
 from click import ClickException
 from collections import OrderedDict
 
@@ -14,8 +15,9 @@ def with__node__group(cmd_func):
 def nodes_in__node__group(options):
     nodes = groups.expand_nodes(options['node'].value)
     for group in options['group'].value:
-        group_nodes = groups.nodes_in(group)
-        if not group_nodes:
+        try:
+            group_nodes = Config.all_groups()[group]
+        except KeyError:
             raise ClickException('Could not find group: {}'.format(group))
         nodes.extend(group_nodes)
     return list(__remove_duplicates(nodes))

--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -22,20 +22,6 @@ def nodes_in__node__group(options):
         nodes.extend(group_nodes)
     return list(__remove_duplicates(nodes))
 
-def set_nodes_context(ctx, **kwargs):
-    # populate ctx.obj with nodes
-    obj = { 'nodes' : [] }
-    if kwargs['node']:
-        obj['nodes'].extend(groups.expand_nodes(kwargs['node']))
-    if kwargs['group']:
-        for group in kwargs['group']:
-            nodes = groups.nodes_in(group)
-            if not nodes:
-                raise ClickException('Could not find group: {}'.format(group))
-            obj['nodes'].extend(nodes)
-    obj['nodes'] = __remove_duplicates(obj['nodes'])
-    ctx.obj = { 'adminware' : obj }
-
 def __remove_duplicates(target_list):
     # gone for the slightly more intensive method that preserves order for pretty output
     return OrderedDict((x, True) for x in target_list).keys()

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -19,14 +19,15 @@ def add_commands(appliance):
     def view():
         pass
 
-    @view.command(help='Lists the available groups')
-    def groups():
-        click.echo_via_pager("\n".join(groups_util.list()))
+    @view.group(help='Lists nodes within a group')
+    def group():
+        pass
 
-    @view.command(help='Lists the nodes within a group')
-    @click.argument('group_name')
-    def group(group_name):
-        click.echo_via_pager("\n".join(groups_util.nodes_in(group_name)))
+    group_command = { 'help': 'View the nodes in this group' }
+    @Config.group_commands(group, command = group_command)
+    def get_group_info(callstack, _a, _o):
+        group_name = callstack[0]
+        click.echo_via_pager("\n".join(Config.all_groups()[group_name]))
 
     @view.command(help='View the result from a previous job')
     @click.argument('job_id', type=int)

--- a/src/commands/view.py
+++ b/src/commands/view.py
@@ -24,10 +24,10 @@ def add_commands(appliance):
         pass
 
     group_command = { 'help': 'View the nodes in this group' }
-    @Config.group_commands(group, command = group_command)
+    @groups_util.group_commands(group, command = group_command)
     def get_group_info(callstack, _a, _o):
         group_name = callstack[0]
-        click.echo_via_pager("\n".join(Config.all_groups()[group_name]))
+        click.echo_via_pager("\n".join(groups_util.nodes_in(group_name)))
 
     @view.command(help='View the result from a previous job')
     @click.argument('job_id', type=int)

--- a/src/groups.py
+++ b/src/groups.py
@@ -1,11 +1,31 @@
 
 # all dependancy on nodeattr is to be located in this file
 import config
+from models.config import Config
+from appliance_cli.command_generation import generate_commands
 
 from plumbum import local, ProcessExecutionError
 from tempfile import NamedTemporaryFile
 from click import ClickException
 from re import search
+
+def group_commands(root_command, **kwargs):
+    def __group_commands(callback):
+        groups_hash = __hashify_all_groups(**kwargs)
+        generate_commands(root_command, groups_hash, callback)
+    return __group_commands
+
+# Generates a similar hash to Config hasify funcs - for node groups
+#   {
+#       groupX: **<node>,
+#       ...
+#   }
+def __hashify_all_groups(command = {}):
+    combined_hash = {}
+    for group in list():
+        group_hash = combined_hash.setdefault(group, {})
+        Config._Config__copy_values(command, group_hash, group)
+    return combined_hash
 
 def list():
     groups = __nodeattr(arguments=['-l'])

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -5,7 +5,6 @@ from os.path import basename, dirname
 import os.path
 from glob import glob
 
-import groups
 from appliance_cli.command_generation import generate_commands
 
 import subprocess
@@ -36,12 +35,6 @@ class Config():
             generate_commands(root_command, families_hash, callback)
         return __family_commands
 
-    def group_commands(root_command, **kwargs):
-        def __group_commands(callback):
-            groups_hash = Config.hashify_all_groups(**kwargs)
-            generate_commands(root_command, groups_hash, callback)
-        return __group_commands
-
     @lru_cache()
     def cache(*a, **kw): return Config(*a, **kw)
 
@@ -58,14 +51,6 @@ class Config():
             for family in config.families():
                 combined_hash.setdefault(family, [])
                 combined_hash[family] += [config]
-        return combined_hash
-
-    @lru_cache()
-    def all_groups():
-        combined_hash = {}
-        groups_list = groups.list()
-        for group in groups_list:
-            combined_hash[group] = groups.nodes_in(group)
         return combined_hash
 
     # The commands are hashed into the following structure
@@ -111,18 +96,6 @@ class Config():
         for family in Config.all_families():
             family_hash = combined_hash.setdefault(family, {})
             Config.__copy_values(command, family_hash, family)
-        return combined_hash
-
-    # Also generates a similar hash - for node groups
-    #   {
-    #       groupX: **<node>,
-    #       ...
-    #   }
-    def hashify_all_groups(command = {}):
-        combined_hash = {}
-        for group in Config.all_groups():
-            group_hash = combined_hash.setdefault(group, {})
-            Config.__copy_values(command, group_hash, group)
         return combined_hash
 
     def __copy_values(source, target, args):


### PR DESCRIPTION
In order to be inline with new `view tool` and `view family` commands, combines `view group` and `view groups` into one. When called with no arguments. it give a list of all groups in the help text.

Involved making functions in `Config` to create the command hash. I also cached the `all_groups` hash - like with `all_configs` and `all_families` - and reused it in `cli_utils` to expand the groups.

Also `set_nodes_config` was made redundant in an earlier commit and I took the liberty to remove it.

If my changes to `cli_utils` are unwanted the last two commits can be reverted.

Additionally for the time being I defined the methods on group hashes in `Config` despite the fact they have nothing to do with configs. I feel like a mode general purpose module is needed but I also feel like it'll do for now.

Fixes #138 