### PR TITLE
Swap import order to prevent cyclical dependencies

### DIFF
--- a/src/db_setup.py
+++ b/src/db_setup.py
@@ -1,8 +1,8 @@
 
 from database import Base, Session, engine
 
-from models import batch
 from models import job
+from models import batch
 
 Base.metadata.create_all(engine)
 


### PR DESCRIPTION
This module is only loaded on setup and thus was missed from earlier work

Job _then_ batch results in no issues with a new setup