### PR TITLE
Implement the report command type

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ families:
 # than one node at once. If it is attempted to run in on more than one node an error
 # will be thrown.
 interactive: True
+
+# Runs the command in reporting mode. The standard output of the remote command will
+# be dumped to the screen instead of the exit code.
+report: True
 ```
 
 # Configuring Run Parameters

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -52,7 +52,7 @@ def add_commands(appliance):
         batch.build_jobs(*nodes)
         if batch.is_interactive():
             if len(batch.jobs) == 1:
-                execute_threaded_batches([batch], quite = True)
+                execute_threaded_batches([batch], quiet = True)
             elif batch.jobs:
                 raise ClickException('''
 '{}' is an interactive tool and can only be ran on a single node
@@ -61,7 +61,7 @@ def add_commands(appliance):
                 raise ClickException('Please specify a node with --node')
         elif batch.jobs:
             report = batch.config_model.report
-            execute_threaded_batches([batch], quite = report)
+            execute_threaded_batches([batch], quiet = report)
         else:
             raise ClickException('Please give either --node or --group')
 
@@ -87,9 +87,9 @@ def add_commands(appliance):
             batches += [batch]
         execute_threaded_batches(batches)
 
-    def execute_threaded_batches(batches, quite = False):
+    def execute_threaded_batches(batches, quiet = False):
         def run_print(string):
-            if quite: return
+            if quiet: return
             click.echo(string)
 
         loop = asyncio.get_event_loop()

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -60,7 +60,8 @@ def add_commands(appliance):
             else:
                 raise ClickException('Please specify a node with --node')
         elif batch.jobs:
-            execute_threaded_batches([batch])
+            report = batch.config_model.report
+            execute_threaded_batches([batch], quite = report)
         else:
             raise ClickException('Please give either --node or --group')
 

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -97,8 +97,8 @@ def add_commands(appliance):
     def execute_threaded_batches(batches):
         loop = asyncio.get_event_loop()
         def handler_interrupt():
-            print('Interrupt Received! ')
-            print('Cancelling the jobs...')
+            click.echo('Interrupt Received! ')
+            click.echo('Cancelling the jobs...')
             for task in asyncio.Task.all_tasks(loop = loop):
                 task.cancel()
         loop.add_signal_handler(signal.SIGINT, handler_interrupt)
@@ -120,9 +120,9 @@ def add_commands(appliance):
                     await asyncio.sleep(0.01)
                 asyncio.ensure_future(task, loop = loop)
                 active_tasks.append(task)
-                print('Starting Job: {}'.format(task.node))
+                click.echo('Starting Job: {}'.format(task.node))
                 await(asyncio.sleep(start_delay))
-            print('Waiting for jobs to finish...')
+            click.echo('Waiting for jobs to finish...')
             while len(active_tasks) > 0:
                 remove_done_tasks()
                 await asyncio.sleep(0.01)
@@ -137,9 +137,9 @@ def add_commands(appliance):
                 loop.run_until_complete(start_tasks(tasks))
         except concurrent.futures.CancelledError: pass
         finally:
-            print('Cleaning up...')
+            click.echo('Cleaning up...')
             pool.shutdown(wait = True)
-            print('Saving...')
+            click.echo('Saving...')
             session.commit()
             Session.remove()
-            print('Done')
+            click.echo('Done')

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -148,6 +148,10 @@ class Config():
     def interactive_only(self):
         return self.interactive()
 
+    def __getattr__(self, attr):
+        return self.data.setdefault(attr)
+
+    # TODO: Use __getattr__ here
     def interactive(self):
         return 'interactive' in self.data and self.data['interactive'] == True
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -144,7 +144,7 @@ class Config():
         if not self.data['families']: self.data['families'] = default
         return self.data['families']
 
-    # Deprecated, avoid usage
+    # TODO: Deprecated, avoid usage
     def interactive_only(self):
         return self.interactive()
 

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -80,12 +80,15 @@ available. Please see documentation for possible causes
                 # print(e)
                 pass
 
-            if self.exit_code == 0:
-                symbol = 'Pass'
+            if self.batch.config_model.report:
+                pass
             else:
-                symbol = 'Failed: {}'.format(self.exit_code)
-            args = [self.id, self.node, symbol]
-            click.echo('ID: {}, Node: {}, {}'.format(*args))
+                if self.exit_code == 0:
+                    symbol = 'Pass'
+                else:
+                    symbol = 'Failed: {}'.format(self.exit_code)
+                args = [self.id, self.node, symbol]
+                click.echo('ID: {}, Node: {}, {}'.format(*args))
 
         async def __run_thread(self, func, *a):
             def catch_errors(func, *args):

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -151,7 +151,6 @@ available. Please see documentation for possible causes
         @__with_tempdir
         def __run_command(temp_dir):
             # Copies the files across
-            path = '/var/lib/adminware/tools/namespace/stutool1/config.yaml'
             parts = [os.path.dirname(batch.config), '*']
             for src_path in glob.glob(os.path.join(*parts)):
                 result = self.connection().put(src_path, temp_dir)

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -61,6 +61,9 @@ available. Please see documentation for possible causes
             self.add_done_callback(callback)
 
         def report_results(self):
+            # Do not report interactive jobs
+            if self.batch.is_interactive(): return
+
             # Do not print cancelled Tasks. `self.cancelled()` can't be used
             # as the Task is now in the "done" state
             try: self.exception()

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -84,7 +84,6 @@ available. Please see documentation for possible causes
                 click.echo('Node: {}'.format(self.node))
                 click.echo(self.stdout)
                 click.echo()
-                pass
             else:
                 if self.exit_code == 0:
                     symbol = 'Pass'

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -60,6 +60,12 @@ available. Please see documentation for possible causes
             callback = lambda task: func(task.job)
             self.add_done_callback(callback)
 
+        # TODO: Set different "report" callbacks for the three different commands:
+        # Possible use inheritance?
+        # Exit Code Commands: print_exit_code
+        # Report Commands:    print_report
+        # Interactive:        noop - do not set the callback
+        # This will remove the logic at runtime
         def report_results(self):
             # Do not report interactive jobs
             if self.batch.is_interactive(): return

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -81,6 +81,9 @@ available. Please see documentation for possible causes
                 pass
 
             if self.batch.config_model.report:
+                click.echo('Node: {}'.format(self.node))
+                click.echo(self.stdout)
+                click.echo()
                 pass
             else:
                 if self.exit_code == 0:


### PR DESCRIPTION
Based on #153, please merge it first. This PR fixes the few printing issues as mentioned in the PR.

The `report` command type is an extension of the `exit  code` commands. The only difference is the `stdout` is dumped to the screen instead of the exit codes. The loop printing has also been disabled as to prevent junk being printed to the output.