### PR TITLE
Add try-except block for config creation

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -89,9 +89,9 @@ No tools found in '{}'
         def __read_data():
             with open(self.path, 'r') as stream:
                 return yaml.load(stream) or {}
-        try:
+        if os.path.isfile(path):
             self.data = __read_data()
-        except FileNotFoundError:
+        else:
             self.data = defaultdict(lambda: 'File not found')
 
     def __name__(self):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -3,6 +3,7 @@ import re
 import click
 from os.path import basename, dirname
 
+from collections import defaultdict
 import os.path
 from glob import glob
 
@@ -88,7 +89,10 @@ No tools found in '{}'
         def __read_data():
             with open(self.path, 'r') as stream:
                 return yaml.load(stream) or {}
-        self.data = __read_data()
+        try:
+            self.data = __read_data()
+        except FileNotFoundError:
+            self.data = defaultdict(lambda: 'File not found')
 
     def __name__(self):
         return basename(dirname(self.path))


### PR DESCRIPTION
Now if FileNotFound error occurs the system will not crash

Also, in the case of the file not being found, a defaultdict will be created for the config instead of the dict created by reading its yaml.
It has the default value for everything 'File Not Found'.
This dict is currently not used for anything as as it stands all queried information comes from the job object but it exists for future utility.

fixes #103 