### PR TITLE
Fix/interrupt multiple tools

### DIFF
--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -70,19 +70,20 @@ def add_commands(appliance):
             if not nodes:
                 raise ClickException('Please give either --node or --group')
 
+        def is_quiet():
+            if len(batches) > 1: return False
+            first = batches[0]
+            if first.is_interactive or first.report: return True
+            else: return False
+
         error_if_no_nodes()
         batches = list(map(lambda c: Batch(config = c.path), configs))
         error_if_interactive_in_tool_groups()
         error_if_multiple_interactive_jobs()
         if not (options['yes'].value or get_confirmation(batches, nodes)):
             return
-        for batch in batches:
-            batch.build_jobs(*nodes)
-            if batch.is_interactive():
-                execute_batches([batch], quiet = True)
-            elif batch.jobs:
-                report = batch.config_model.report
-                execute_batches([batch], quiet = report)
+        for batch in batches: batch.build_jobs(*nodes)
+        execute_batches(batches, quiet = is_quiet())
 
     def execute_batches(batches, quiet = False):
         def run_print(string):

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -149,7 +149,7 @@ You are about to run:
 Over {}:
   {}
 """.strip().format(tool_names, node_tag, node_names))
-        question = "Please enter [y/N] to confirm"
+        question = "Please enter [y/n] to confirm"
         affirmatives = ['y', 'ye', 'yes']
         reply = click.prompt(question).lower()
         if reply in affirmatives:

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -58,7 +58,7 @@ def add_commands(appliance):
             batch.build_jobs(*nodes)
             if batch.is_interactive():
                 if len(batch.jobs) == 1:
-                    execute_threaded_batches([batch], quiet = True)
+                    execute_batches([batch], quiet = True)
                 elif batch.jobs:
                     raise ClickException('''
 '{}' is an interactive tool and can only be ran on a single node
@@ -67,11 +67,11 @@ def add_commands(appliance):
                     raise ClickException('Please specify a node with --node')
             elif batch.jobs:
                 report = batch.config_model.report
-                execute_threaded_batches([batch], quiet = report)
+                execute_batches([batch], quiet = report)
             else:
                 raise ClickException('Please give either --node or --group')
 
-    def execute_threaded_batches(batches, quiet = False):
+    def execute_batches(batches, quiet = False):
         def run_print(string):
             if quiet: return
             click.echo(string)

--- a/src/groups.py
+++ b/src/groups.py
@@ -17,6 +17,9 @@ def nodes_in(group_name):
 def compress_nodes(node_list):
     return _create_tmp_genders_file(node_list, arguments = ['--compress'])[0]
 
+def compress_nodes(node_list):
+    return create_tmp_genders_file(node_list, arguments = ['--compress'])
+
 def expand_nodes(node_list):
     return _create_tmp_genders_file(node_list, arguments = ['--expand'])
 
@@ -33,7 +36,10 @@ May only contain alphanumeric characters and the following symbols: , [ ]
     tmp_file = NamedTemporaryFile(dir='/tmp/', prefix='adminware-genders')
     with open(tmp_file.name, 'w') as f:
         f.write('\n'.join(node_list))
-    return _nodeattr(file_path = tmp_file.name, arguments = arguments)
+    nodes = _nodeattr(file_path = tmp_file.name, arguments = arguments)
+    # above split adds trailing empty string in array so
+    del nodes[-1]
+    return nodes
 
 def _nodeattr(file_path = config.GENDERS, arguments=[], split_char="\n"):
     if not os.path.isfile(file_path): return []

--- a/src/groups.py
+++ b/src/groups.py
@@ -33,10 +33,7 @@ May only contain alphanumeric characters and the following symbols: , [ ]
     tmp_file = NamedTemporaryFile(dir='/tmp/', prefix='adminware-genders')
     with open(tmp_file.name, 'w') as f:
         f.write('\n'.join(node_list))
-    nodes = _nodeattr(file_path = tmp_file.name, arguments = arguments)
-    # above split adds trailing empty string in array so
-    del nodes[-1]
-    return nodes
+    return _nodeattr(file_path = tmp_file.name, arguments = arguments)
 
 def _nodeattr(file_path = config.GENDERS, arguments=[], split_char="\n"):
     if not os.path.isfile(file_path): return []

--- a/src/groups.py
+++ b/src/groups.py
@@ -17,9 +17,6 @@ def nodes_in(group_name):
 def compress_nodes(node_list):
     return _create_tmp_genders_file(node_list, arguments = ['--compress'])[0]
 
-def compress_nodes(node_list):
-    return create_tmp_genders_file(node_list, arguments = ['--compress'])
-
 def expand_nodes(node_list):
     return _create_tmp_genders_file(node_list, arguments = ['--expand'])
 


### PR DESCRIPTION
Small changes to `run`

Renames `execute_threaded_batches` to execute_batches as it no longer truly uses threads

Stops an interrupt not properly stopping all executing tools (Fixes #164). 
In the end I went with just raising a `ClickException` over raising a `KeyboardInterrupt`, re-rasing a `CancelledError` or somehow manually signalling back that there'd been an interrupt. What do you think?
The 'Aborted!' text is to be inline with how click receives an interrupt in any other places