### PR TITLE
Various tweaks and refactoring

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,6 +12,7 @@ DateTime==4.2
 decorator==4.0.11
 fabric==2.4.0
 idna==2.7
+inflect==2.1.0
 invoke==1.2.0
 ipython==5.3.0
 ipython-genutils==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ DateTime==4.2
 decorator==4.0.11
 fabric==2.4.0
 idna==2.7
+inflect==2.1.0
 invoke==1.2.0
 ipython==5.3.0
 ipython-genutils==0.1.0

--- a/src/command_creator.py
+++ b/src/command_creator.py
@@ -89,7 +89,7 @@ def glob_configs(parts = []):
 #   }
 def __hashify_all_groups(command = {}):
      combined_hash = {}
-     for group in groups_util.list_groups():
+     for group in groups_util.list_():
          group_hash = combined_hash.setdefault(group, {})
          __copy_values(command, group_hash, group)
      return combined_hash

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -52,7 +52,7 @@ def add_commands(appliance):
                 if config.interactive():
                     raise ClickException('''
 '{}' is an interactive tool and cannot be ran as part of a group
-'''.format(config.__name__()).strip())
+'''.format(config.name()).strip())
         for config in configs:
             batch = Batch(config = config.path)
             batch.build_jobs(*nodes)
@@ -113,7 +113,7 @@ def add_commands(appliance):
             for batch in batches:
                 session.add(batch)
                 session.commit()
-                run_print('Executing: {}'.format(batch.__name__()))
+                run_print('Executing: {}'.format(batch.name()))
                 tasks = map(lambda j: j.task(thread_pool = pool), batch.jobs)
                 loop.run_until_complete(start_tasks(tasks))
         except concurrent.futures.CancelledError: pass

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -33,7 +33,6 @@ def add_commands(appliance):
 
     runner_cmd = {
         'help': Config.help,
-        'arguments': [['remote_arguments']], # [[]]: Optional Arg
         **run_options
     }
     runner_group = {
@@ -45,10 +44,9 @@ def add_commands(appliance):
     @command_creator.tools(run, command = runner_cmd, group = runner_group)
     @cli_utils.with__node__group
     @cli_utils.ignore_parent_commands
-    def runner(_ctx, configs, argv, options, nodes):
-        if not (options['yes'].value or get_confirmation(configs, nodes)):
+    def runner(_ctx, configs, _a, opts, nodes):
+        if not (opts['yes'].value or get_confirmation(configs, nodes)):
             return
-        if not argv: argv = [None]
         if len(configs) > 1:
             for config in configs:
                 if config.interactive():
@@ -56,7 +54,7 @@ def add_commands(appliance):
 '{}' is an interactive tool and cannot be ran as part of a group
 '''.format(config.__name__()).strip())
         for config in configs:
-            batch = Batch(config = config.path, arguments = (argv[0] or ''))
+            batch = Batch(config = config.path)
             batch.build_jobs(*nodes)
             if batch.is_interactive():
                 if len(batch.jobs) == 1:

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -127,7 +127,7 @@ def add_commands(appliance):
 
     def get_confirmation(configs, nodes):
         tool_names = '\n'.join([c.name() for c in configs])
-        node_names = groups_util.compress_nodes(nodes)[0].replace('],', ']\n  ')
+        node_names = groups_util.compress_nodes(nodes).replace('],', ']\n  ')
         node_tag = 'node' if len(nodes) == 1 else 'nodes'
         click.echo("""
 You are about to run:

--- a/src/commands/status.py
+++ b/src/commands/status.py
@@ -74,7 +74,7 @@ def add_commands(appliance):
             ['Job ID', job.id],
             ['Node', job.node],
             ['Exit Code', job.exit_code],
-            ['Tool', job.batch.__name__()],
+            ['Tool', job.batch.name()],
             ['STDOUT', job.stdout],
             ['STDERR', job.stderr]
         ]

--- a/src/commands/status.py
+++ b/src/commands/status.py
@@ -75,7 +75,6 @@ def add_commands(appliance):
             ['Node', job.node],
             ['Exit Code', job.exit_code],
             ['Tool', job.batch.__name__()],
-            ['Arguments', job.batch.arguments],
             ['STDOUT', job.stdout],
             ['STDERR', job.stderr]
         ]
@@ -120,7 +119,6 @@ def add_commands(appliance):
                    'Tool',
                    'Job ID',
                    'Exit Code',
-                   'Arguments',
                    'Date']
 
         if opts['history'].value: jobs += run_query()
@@ -142,12 +140,10 @@ def add_commands(appliance):
 
         rows = []
         for job in jobs:
-            arguments = None if not job.batch.arguments else job.batch.arguments
             row = [job.node,
                    job.batch.config_model.name(),
                    job.id,
                    job.exit_code,
-                   arguments,
                    job.created_date]
             if isinstance(job.count, int): row.append(job.count)
             rows += [row]

--- a/src/database.py
+++ b/src/database.py
@@ -21,16 +21,21 @@ class Base(object):
     def __tablename__(cls):
         return inflect.plural(cls.__name__.lower())
 
+
     id = Column(Integer, primary_key=True)
 
-Base = declare.declarative_base(cls=Base)
 
-class InitOrLoadModel(object):
-    def __init__(self, *a, **kwargs):
-        super().__init__(*a, **kwargs)
+    def __init__(self, **kwargs):
+        declare.api._declarative_constructor(self, **kwargs)
         self.__init_or_load__()
 
     @orm.reconstructor
-    def __load__(self): self.__init_or_load__()
+    def __reconstruct(self):
+        self.__load__()
+        self.__init_or_load__()
+
+    def __load__(self): pass
     def __init_or_load__(self): pass
+
+Base = declare.declarative_base(cls=Base, constructor = None)
 

--- a/src/database.py
+++ b/src/database.py
@@ -2,7 +2,7 @@
 import config
 import inflect as inflect_module
 
-from sqlalchemy import create_engine, Column, Integer
+from sqlalchemy import create_engine, Column, Integer, orm
 import sqlalchemy.ext.declarative as declare
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import scoped_session
@@ -24,3 +24,13 @@ class Base(object):
     id = Column(Integer, primary_key=True)
 
 Base = declare.declarative_base(cls=Base)
+
+class InitOrLoadModel(object):
+    def __init__(self, *a, **kwargs):
+        super().__init__(*a, **kwargs)
+        self.__init_or_load__()
+
+    @orm.reconstructor
+    def __load__(self): self.__init_or_load__()
+    def __init_or_load__(self): pass
+

--- a/src/database.py
+++ b/src/database.py
@@ -27,15 +27,15 @@ class Base(object):
 
     def __init__(self, **kwargs):
         declare.api._declarative_constructor(self, **kwargs)
-        self.__init_or_load__()
+        self._init_or_load()
 
     @orm.reconstructor
     def __reconstruct(self):
-        self.__load__()
-        self.__init_or_load__()
+        self._load()
+        self._init_or_load()
 
-    def __load__(self): pass
-    def __init_or_load__(self): pass
+    def _load(self): pass
+    def _init_or_load(self): pass
 
 Base = declare.declarative_base(cls=Base, constructor = None)
 

--- a/src/database.py
+++ b/src/database.py
@@ -1,8 +1,9 @@
 
 import config
+import inflect as inflect_module
 
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import create_engine, Column, Integer
+import sqlalchemy.ext.declarative as declare
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import scoped_session
 
@@ -10,4 +11,16 @@ engine = create_engine('sqlite:///{}database.db'.format(config.LEADER))
 session_factory = sessionmaker(bind=engine)
 Session = scoped_session(session_factory)
 
-Base = declarative_base()
+# Typically inflect would the module name and engine dose the inflection
+# However `engine` is already taken by the db, so the naming has been tweaked
+# https://stackoverflow.com/a/42355087
+inflect = inflect_module.engine()
+
+class Base(object):
+    @declare.declared_attr
+    def __tablename__(cls):
+        return inflect.plural(cls.__name__.lower())
+
+    id = Column(Integer, primary_key=True)
+
+Base = declare.declarative_base(cls=Base)

--- a/src/groups.py
+++ b/src/groups.py
@@ -8,7 +8,7 @@ from plumbum import local, ProcessExecutionError
 from tempfile import NamedTemporaryFile
 from re import search
 
-def list_groups():
+def list_():
     groups = __nodeattr(arguments=['-l'])
     return groups
 

--- a/src/groups.py
+++ b/src/groups.py
@@ -9,12 +9,10 @@ from tempfile import NamedTemporaryFile
 from re import search
 
 def list_():
-    groups = __nodeattr(arguments=['-l'])
-    return groups
+    return _nodeattr(arguments=['-l'])
 
 def nodes_in(group_name):
-    nodes = __nodeattr(arguments=['-n', group_name])
-    return nodes
+    return _nodeattr(arguments=['-n', group_name])
 
 def compress_nodes(node_list):
     return _create_tmp_genders_file(node_list, arguments = ['--compress'])
@@ -24,21 +22,20 @@ def expand_nodes(node_list):
 
 def _create_tmp_genders_file(node_list,  arguments = []):
     # intercept to generate a more useful error message
-    #   before invalid nodenames are caught generically in __nodeattr
+    #   before invalid nodenames are caught generically in _nodeattr
     for node in node_list:
         if search(r'[^A-z0-9,\[\]]', node):
             raise click.ClickException("""
-Invalid nodename {}
+Invalid node '{}'
 May only contain alphanumeric characters and the following symbols: , [ ]
 """.strip().format(node))
     # build and parse a genders file of the nodes
     tmp_file = NamedTemporaryFile(dir='/tmp/', prefix='adminware-genders')
     with open(tmp_file.name, 'w') as f:
         f.write('\n'.join(node_list))
-    nodes = __nodeattr(file_path=tmp_file.name, arguments=arguments)
-    return nodes
+    return _nodeattr(file_path = tmp_file.name, arguments = arguments)
 
-def __nodeattr(file_path = config.GENDERS, arguments=[], split_char="\n"):
+def _nodeattr(file_path = config.GENDERS, arguments=[], split_char="\n"):
     if not os.path.isfile(file_path): return []
     try:
         # 'split' below leaves empty string on the end of the array

--- a/src/groups.py
+++ b/src/groups.py
@@ -15,7 +15,7 @@ def nodes_in(group_name):
     return _nodeattr(arguments=['-n', group_name])
 
 def compress_nodes(node_list):
-    return _create_tmp_genders_file(node_list, arguments = ['--compress'])
+    return _create_tmp_genders_file(node_list, arguments = ['--compress'])[0]
 
 def expand_nodes(node_list):
     return _create_tmp_genders_file(node_list, arguments = ['--expand'])

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -13,7 +13,7 @@ class Batch(Base):
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
 
 
-    def __init_or_load__(self):
+    def _init_or_load(self):
         self.config_model = Config(self.config)
 
     def name(self):

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -16,9 +16,6 @@ class Batch(Base):
     def __init_or_load__(self):
         self.config_model = Config(self.config)
 
-    def __name__(self):
-        return self.config_model.__name__()
-
     def name(self):
         return self.config_model.name()
 

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -1,17 +1,20 @@
 
 import datetime
-from sqlalchemy import Column, String, Integer, DateTime, orm
+from sqlalchemy import Column, String, Integer, DateTime
 
-from database import Base
+from database import Base, InitOrLoadModel
 from models.config import Config
 from models.job import Job
 
-class Batch(Base):
+class Batch(InitOrLoadModel, Base):
 
 
     config = Column(String)
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
 
+
+    def __init_or_load__(self):
+        self.config_model = Config(self.config)
 
     def __name__(self):
         return self.config_model.__name__()
@@ -33,14 +36,3 @@ class Batch(Base):
 
     def build_jobs(self, *nodes):
         return list(map(lambda n: Job(node = n, batch = self), nodes))
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.__init_or_load__()
-
-    @orm.reconstructor
-    def __load__(self):
-        self.__init_or_load__()
-
-    def __init_or_load__(self):
-        self.config_model = Config(self.config)

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -36,11 +36,11 @@ class Batch(Base):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.__init_or_load()
+        self.__init_or_load__()
 
     @orm.reconstructor
-    def __load(self):
-        self.__init_or_load()
+    def __load__(self):
+        self.__init_or_load__()
 
-    def __init_or_load(self):
+    def __init_or_load__(self):
         self.config_model = Config(self.config)

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -12,7 +12,6 @@ class Batch(Base):
 
     id = Column(Integer, primary_key=True)
     config = Column(String)
-    arguments = Column(String)
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
 
 
@@ -39,7 +38,6 @@ class Batch(Base):
 
     def __init__(self, **kwargs):
         self.config = kwargs['config']
-        self.arguments = kwargs.setdefault('arguments')
         self.__init_or_load()
 
     @orm.reconstructor

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -2,11 +2,11 @@
 import datetime
 from sqlalchemy import Column, String, Integer, DateTime
 
-from database import Base, InitOrLoadModel
+from database import Base
 from models.config import Config
 from models.job import Job
 
-class Batch(InitOrLoadModel, Base):
+class Batch(Base):
 
 
     config = Column(String)

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -7,10 +7,8 @@ from models.config import Config
 from models.job import Job
 
 class Batch(Base):
-    __tablename__ = 'batches'
 
 
-    id = Column(Integer, primary_key=True)
     config = Column(String)
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
 
@@ -37,7 +35,7 @@ class Batch(Base):
         return list(map(lambda n: Job(node = n, batch = self), nodes))
 
     def __init__(self, **kwargs):
-        self.config = kwargs['config']
+        super().__init__(**kwargs)
         self.__init_or_load()
 
     @orm.reconstructor

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -23,12 +23,10 @@ class Config():
     @lru_cache()
     def cache(*a, **kw): return Config(*a, **kw)
 
-    def __name__(self):
-        return basename(dirname(self.path))
-
     def name(self):
         prefix = (self.additional_namespace() + ' ' if self.additional_namespace() else '')
-        return "{}{}".format(prefix, self.__name__())
+        last_name = basename(dirname(self.path))
+        return "{}{}".format(prefix, last_name)
 
     def names(self):
         return self.name().split()
@@ -41,13 +39,13 @@ class Config():
         return namespace_path.translate(namespace_path.maketrans('/', ' ')).strip()
 
     def command(self):
-        default = 'MISSING: Command for {}'.format(self.__name__())
+        default = 'MISSING: Command for {}'.format(self.name())
         self.data.setdefault('command', default)
         if not self.data['command']: self.data['command'] = default
         return self.data['command']
 
     def help(self):
-        default = 'MISSING: Help for {}'.format(self.__name__())
+        default = 'MISSING: Help for {}'.format(self.name())
         self.data.setdefault('help', default)
         if not self.data['help']: self.data['help'] = default
         return self.data['help']

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -19,10 +19,8 @@ import functools
 
 @functools.total_ordering
 class Job(Base):
-    __tablename__ = 'jobs'
 
 
-    id = Column(Integer, primary_key=True)
     node = Column(String)
     created_date = Column(DateTime, default=datetime.datetime.utcnow)
     stdout = Column(String)
@@ -44,12 +42,9 @@ available. Please see documentation for possible causes
     __connection = None
     __result = None
 
+
     def config(self):
         return self.batch.config_model
-
-    def __init__(self, **kwargs):
-        self.node = kwargs['node']
-        self.batch = kwargs['batch']
 
     def __lt__(self, other):
         if self.node == other.node:

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -186,7 +186,6 @@ available. Please see documentation for possible causes
                 else:
                     kwargs.update({ 'hide': 'both' })
                 cmd = batch.command()
-                if batch.arguments: cmd = cmd + ' ' + quote(batch.arguments)
                 return self.connection().run(cmd, **kwargs)
         self.__result = __run_command()
 


### PR DESCRIPTION
This PR contains various changes required for re-implementing the argument passing. The main user facing change is the complete removal of the current `argument` passing as recommended in #163. This will allow the arguments to be reworked in a future PR.

There has been a few naming tweaks following the standard python naming conventions. However this is by no means complete and will need further work. See issue #170 

The final major change is updates to the `database.Base` model. It now contains shared code between all the database models:
1. The table name is always the plural of the model name,
2. The constructor has been moved to the base class (this was always the case but not used)
3. All tables have an integer primary key
4. The `reconstructor` has been baked into the `Base`  