### PR TITLE
Dev/fix encapsulation

### DIFF
--- a/src/cli_utils.py
+++ b/src/cli_utils.py
@@ -19,10 +19,10 @@ hash__node__group = {
 }
 
 def with__node__group(cmd_func):
-    def __with__node__group(ctx, config, argv, options, *a):
+    def _with__node__group(ctx, config, argv, options, *a):
         nodes = nodes_in__node__group(options)
         cmd_func(ctx, config, argv, options, *a, nodes)
-    return __with__node__group
+    return _with__node__group
 
 def nodes_in__node__group(options):
     nodes = groups.expand_nodes(options['node'].value)
@@ -31,14 +31,14 @@ def nodes_in__node__group(options):
         if not group_nodes:
             raise ClickException('Could not find group: {}'.format(group))
         nodes.extend(group_nodes)
-    return list(__remove_duplicates(nodes))
+    return list(_remove_duplicates(nodes))
 
-def __remove_duplicates(target_list):
+def _remove_duplicates(target_list):
     # gone for the slightly more intensive method that preserves order for pretty output
     return OrderedDict((x, True) for x in target_list).keys()
 
 def ignore_parent_commands(func):
-    def __wrapper(ctx, *args, **kwargs):
+    def _wrapper(ctx, *args, **kwargs):
         if not ctx.invoked_subcommand:
             func(ctx, *args, **kwargs)
-    return __wrapper
+    return _wrapper

--- a/src/command_creator.py
+++ b/src/command_creator.py
@@ -28,19 +28,19 @@ No tools found in '{}'
     kwargs['group']['pass_context'] = True
     kwargs['command']['pass_context'] = True
 
-    def __tools(config_callback):
-        config_hash = __hashify_all(subcommand_key = 'commands', **kwargs)
+    def _tools(config_callback):
+        config_hash = _hashify_all(subcommand_key = 'commands', **kwargs)
         callback = ConfigCallback(config_callback).run
         generate_commands(root_command, config_hash, callback)
-    return __tools
+    return _tools
 
 def groups(root_command, **kwargs):
     kwargs['command']['pass_context'] = True
 
-    def __groups(callback):
-        groups_hash = __hashify_all_groups(**kwargs)
+    def _groups(callback):
+        groups_hash = _hashify_all_groups(**kwargs)
         generate_commands(root_command, groups_hash, callback)
-    return __groups
+    return _groups
 
 # The commands are hashed into the following structure
 # NOTES: `command` and `group` both supports callable objects as a means
@@ -57,43 +57,43 @@ def groups(root_command, **kwargs):
 #           }
 #       }
 #   }
-def __hashify_all(group = {}, command = {}, subcommand_key = ''):
+def _hashify_all(group = {}, command = {}, subcommand_key = ''):
     def build_group_hashes():
         cur_hash = combined_hash
         names = config.names()
         for idx, name in enumerate(config.names()):
             cur_names = names[0:idx]
-            __copy_values(group, cur_hash, cur_names)
+            _copy_values(group, cur_hash, cur_names)
             cur_hash = cur_hash.setdefault(subcommand_key, {})\
                                .setdefault(name, {})
         return cur_hash
 
     combined_hash = {}
     for config in glob_configs():
-        __copy_values(command, build_group_hashes(), config)
+        _copy_values(command, build_group_hashes(), config)
 
     return combined_hash.setdefault(subcommand_key, {})
 
 @lru_cache()
-def __glob_paths(*parts):
+def _glob_paths(*parts):
     path = os.path.join(config.TOOL_DIR, *parts, '**/config.yaml')
     return glob(path, recursive=True)
 
 def glob_configs(parts = []):
-    return list(map(lambda p: Config.cache(p), __glob_paths(*parts)))
+    return list(map(lambda p: Config.cache(p), _glob_paths(*parts)))
 
 # Generates a similar hash to Config hasify func - for node groups
 #   {
 #       groupX: **<node>,
 #       ...
 #   }
-def __hashify_all_groups(command = {}):
+def _hashify_all_groups(command = {}):
      combined_hash = {}
      for group in groups_util.list_():
          group_hash = combined_hash.setdefault(group, {})
-         __copy_values(command, group_hash, group)
+         _copy_values(command, group_hash, group)
      return combined_hash
 
-def __copy_values(source, target, args):
+def _copy_values(source, target, args):
    for k, v in source.items():
        target[k] = (v(args) if callable(v) else v)

--- a/src/commands/status.py
+++ b/src/commands/status.py
@@ -58,7 +58,7 @@ def add_commands(appliance):
     }
 
     @command_creator.tools(click_cmd, command = status_cmd, group = status_grp)
-    def __run_status(*a): run_status(*a)
+    def _run_status(*a): run_status(*a)
 
     @cli_utils.ignore_parent_commands
     def run_status(ctx, _, argv, opts):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -12,11 +12,11 @@ import config
 class Config():
     def __init__(self, path):
         self.path = path
-        def __read_data():
+        def _read_data():
             with open(self.path, 'r') as stream:
                 return yaml.load(stream) or {}
         if os.path.isfile(path):
-            self.data = __read_data()
+            self.data = _read_data()
         else:
             self.data = defaultdict(lambda: 'File not found')
 

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -39,8 +39,8 @@ available. Please see documentation for possible causes
     # object for readability purposes
     count = None
 
-    __connection = None
-    __result = None
+    _connection = None
+    _result = None
 
 
     def config(self):
@@ -58,8 +58,8 @@ available. Please see documentation for possible causes
             return self.node < other.node
 
     def connection(self):
-        if not self.__connection: self.__connection = Connection(self.node)
-        return self.__connection
+        if not self._connection: self._connection = Connection(self.node)
+        return self._connection
 
     class JobTask(asyncio.Task):
         def __init__(self, job, thread_pool = None):
@@ -109,7 +109,7 @@ available. Please see documentation for possible causes
                 args = [self.id, self.node, symbol]
                 click.echo('ID: {}, Node: {}, {}'.format(*args))
 
-        async def __run_thread(self, func, *a):
+        async def _run_thread(self, func, *a):
             def catch_errors(func, *args):
                 try: func(*args)
                 except: pass
@@ -119,11 +119,11 @@ available. Please see documentation for possible causes
 
         async def run_async(self):
             if self.check_command():
-                try: await self.__run_thread(self.connection().open)
+                try: await self._run_thread(self.connection().open)
                 except concurrent.futures.CancelledError as e: raise e
 
                 if self.connection().is_connected:
-                    await self.__run_thread(self.run, self.batch)
+                    await self._run_thread(self.run, self.batch)
                 else:
                     self.set_ssh_error()
 
@@ -142,18 +142,18 @@ available. Please see documentation for possible causes
         self.exit_code = -1
 
     def set_ssh_results(self):
-        if self.__result == None: return
+        if self._result == None: return
         if self.batch.is_interactive():
             self.stdout = 'Interactive Job: STDOUT is unavailable'
             self.stderr = 'Interactive Job: STDERR is unavailable'
             self.exit_code = -3
         else:
-            self.stdout = self.__result.stdout
-            self.stderr = self.__result.stderr
-            self.exit_code = self.__result.return_code
+            self.stdout = self._result.stdout
+            self.stderr = self._result.stderr
+            self.exit_code = self._result.return_code
 
     def run(self, batch):
-        def __with_tempdir(func):
+        def _with_tempdir(func):
             def wrapper(*args):
                 result = self.connection().run('mktemp -d', hide='both')
                 if result:
@@ -165,8 +165,8 @@ available. Please see documentation for possible causes
                 return result
             return wrapper
 
-        @__with_tempdir
-        def __run_command(temp_dir):
+        @_with_tempdir
+        def _run_command(temp_dir):
             # Copies the files across
             parts = [os.path.dirname(batch.config), '*']
             for src_path in glob.glob(os.path.join(*parts)):
@@ -182,7 +182,7 @@ available. Please see documentation for possible causes
                     kwargs.update({ 'hide': 'both' })
                 cmd = batch.command()
                 return self.connection().run(cmd, **kwargs)
-        self.__result = __run_command()
+        self._result = _run_command()
 
 from models.batch import Batch
 


### PR DESCRIPTION
Fixes #170 

In order to align ourselves with python standards, methods and variables that have been erroneously started with double underscores to indicate that it is a non-public definition are being updated. They should be single underscored in this case.
See the style guide here:
https://www.python.org/dev/peps/pep-0008/#method-names-and-instance-variables

This should likely be merged through as the last change before the next RC, due to potential for conflicts.