### PR TITLE
Fix the status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ interactive: True
 # Runs the command in reporting mode. The standard output of the remote command will
 # be dumped to the screen instead of the exit code.
 report: True
+
+# The following list form the arguments to the command line. They are set as bash shell
+# variables when running the command. This allows them to be used within the command
+# NOTE: this key is optional
+arguments:
+  - arg1
+  - arg2
+  ...
 ```
 
 # Configuring Run Parameters

--- a/src/appliance_cli/command_generation.py
+++ b/src/appliance_cli/command_generation.py
@@ -173,7 +173,7 @@ def _form_arguments(arguments_config):
             is_required = False
             for n in arg_n: add_argument(n)
         else:
-            add_argument(arg_name)
+            add_argument(arg_n)
     return args_map
 
 

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -33,7 +33,8 @@ def add_commands(appliance):
 
     runner_cmd = {
         'help': Config.help,
-        **run_options
+        **run_options,
+        'arguments': Config.args
     }
     runner_group = {
         'help': (lambda names: "Run tools in {}".format(' '.join(names))),

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -67,10 +67,18 @@ def add_commands(appliance):
             if first.interactive() or first.report: return True
             else: return False
 
+        def argument_hash(config):
+            keys = config.args()
+            arg_hash = {}
+            for index, value in enumerate(argv):
+                arg_hash[keys[index]] = value
+            return arg_hash
+
         def build_batches():
             def build(config):
                 batch = Batch(config = config.path)
                 batch.build_jobs(*nodes)
+                batch.build_shell_variables(**argument_hash(config))
                 return batch
             return list(map(lambda c: build(c), configs))
 

--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -147,6 +147,9 @@ Over {}:
             for batch in batches:
                 session.add(batch)
                 session.commit()
+                # Ensure the models are loaded from the db
+                batch.jobs
+                batch.shell_variables
                 run_print('Executing: {}'.format(batch.name()))
                 tasks = map(lambda j: j.task(thread_pool = pool), batch.jobs)
                 loop.run_until_complete(start_tasks(tasks))

--- a/src/commands/status.py
+++ b/src/commands/status.py
@@ -61,10 +61,10 @@ def add_commands(appliance):
     def _run_status(*a): run_status(*a)
 
     @cli_utils.ignore_parent_commands
-    def run_status(ctx, _, argv, opts):
+    def run_status(ctx, configs, argv, opts):
         job_id = opts['job'].value
         if isinstance(job_id, int): view_job(job_id)
-        else: get_status(ctx, [], argv, opts)
+        else: get_status(ctx, configs, argv, opts)
 
     def view_job(job_id):
         job = Session().query(Job).get(job_id)

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, String
 from database import Base
 from models.config import Config
 from models.job import Job
+from models.shell_variable import ShellVariable
 
 class Batch(Base):
 
@@ -31,3 +32,9 @@ class Batch(Base):
 
     def build_jobs(self, *nodes):
         return list(map(lambda n: Job(node = n, batch = self), nodes))
+
+    def build_shell_variables(self, **variables):
+        def build(key):
+            args = { 'key': key, 'value': variables[key], 'batch': self }
+            return ShellVariable(**args)
+        return list(map(lambda k: build(k), variables.keys()))

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -42,4 +42,5 @@ class Batch(Base):
         def build(key):
             args = { 'key': key, 'value': variables[key], 'batch': self }
             return ShellVariable(**args)
+
         return list(map(lambda k: build(k), variables.keys()))

--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -22,7 +22,12 @@ class Batch(Base):
         return self.config_model.help()
 
     def command(self):
-        return self.config_model.command()
+        var_models = self.shell_variables
+        var_map = map(lambda v: '='.join([v.key, v.value]), var_models)
+        var_str = ' && '.join(var_map)
+        cmd = self.config_model.command()
+        if var_str: cmd = ' && '.join([var_str, cmd])
+        return cmd
 
     def command_exists(self):
         return self.config_model.command_exists()

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -50,6 +50,9 @@ class Config():
         if not self.data['help']: self.data['help'] = default
         return self.data['help']
 
+    def args(self):
+        return self.arguments or []
+
     # TODO: Deprecated, avoid usage
     def interactive_only(self):
         return self.interactive()

--- a/src/models/shell_variable.py
+++ b/src/models/shell_variable.py
@@ -1,6 +1,6 @@
 
 from sqlalchemy import Column, String, Integer, ForeignKey
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, validates
 
 from database import Base
 
@@ -11,3 +11,9 @@ class ShellVariable(Base):
     value = Column(String)
     batch_id = Column(Integer, ForeignKey('batches.id'))
     batch = relationship("Batch", backref="shell_variables")
+
+
+    @validates('value')
+    def validate_value(self, _, value):
+        assert value.isalnum()
+        return value

--- a/src/models/shell_variable.py
+++ b/src/models/shell_variable.py
@@ -4,6 +4,8 @@ from sqlalchemy.orm import relationship, validates
 
 from database import Base
 
+import click
+
 class ShellVariable(Base):
 
 
@@ -15,5 +17,8 @@ class ShellVariable(Base):
 
     @validates('value')
     def validate_value(self, _, value):
-        assert value.isalnum()
-        return value
+        try:
+            assert value.isalnum()
+            return value
+        except AssertionError:
+            raise click.ClickException('The arguments must be alphanumeric')

--- a/src/models/shell_variable.py
+++ b/src/models/shell_variable.py
@@ -1,0 +1,13 @@
+
+from sqlalchemy import Column, String, Integer, ForeignKey
+from sqlalchemy.orm import relationship
+
+from database import Base
+
+class ShellVariable(Base):
+
+
+    key = Column(String)
+    value = Column(String)
+    batch_id = Column(Integer, ForeignKey('batches.id'))
+    batch = relationship("Batch", backref="shell_variables")


### PR DESCRIPTION
Based on #175 

This is fairly simple fix to the status command. The `configs` weren't being passed into the command, as such the root `status` command would always run. Fixes #173 