### PR TITLE
Clean up the async `start_task`

### DIFF
--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -126,7 +126,7 @@ Over {}:
             active_tasks = []
             def remove_done_tasks():
                 for active_task in active_tasks:
-                    if active_task._state == 'FINISHED':
+                    if active_task.finished:
                         active_tasks.remove(active_task)
                         break
             for task in tasks:

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -68,6 +68,9 @@ available. Please see documentation for possible causes
             self.add_job_callback(lambda job: job.set_ssh_results())
             self.add_done_callback(type(self).report_results)
 
+        def finished(self):
+            return self._state == 'FINISHED'
+
         def __getattr__(self, attr):
             return getattr(self.job, attr)
 

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -64,9 +64,13 @@ available. Please see documentation for possible causes
             self.thread_pool = thread_pool
             super().__init__(self.run_async())
             self.job = job
-            self.add_job_callback(lambda job: job.connection().close())
+            self.add_job_callback(type(self).close)
             self.add_job_callback(lambda job: job.set_ssh_results())
             self.add_done_callback(type(self).report_results)
+
+        def close(self):
+            try: job.connection.close()
+            except: pass
 
         def finished(self):
             return self._state == 'FINISHED'
@@ -120,8 +124,7 @@ available. Please see documentation for possible causes
 
         async def run_async(self):
             if self.check_command():
-                try: await self._run_thread(self.connection().open)
-                except concurrent.futures.CancelledError as e: raise e
+                await self._run_thread(self.connection().open)
 
                 if self.connection().is_connected:
                     await self._run_thread(self.run, self.batch)


### PR DESCRIPTION
Based on #176 

This PR cleans up the `start_task` async method. Most of the changes are code readability changes and do not affect functionality.

There has been a change in the control logic concerning interrupt. Previously all the futures where being cancelled. This is fine for the `JobTask`s as this triggers them to shutdown as expected. However it also cancels the main future which is running `start_tasks`. This will kill the event loop prematurely and makes the callback behaviour of the other futures difficult to predict.

Instead the `start_tasks` will catch the `CancelledError` and still shutdown as per normal. This prevents additional futures from starting BUT allows currently running (/recently cancelled) futures to shutdown gracefully.