### PR TITLE
Stop stack trace printing on run

### DIFF
--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -126,7 +126,7 @@ Over {}:
             active_tasks = []
             def remove_done_tasks():
                 for active_task in active_tasks:
-                    if active_task.finished:
+                    if active_task.finished():
                         active_tasks.remove(active_task)
                         break
 


### PR DESCRIPTION
Was previous testing for the existence of the function, always resulting in a truthy value

Now should actually remove tasks from the active list, stopping massive queues forming

Should hopefully fix #181 but due to it's nature as an intermittent bug this is inconclusive