### PR TITLE
Fix/argument robustness

### DIFF
--- a/src/models/batch.py
+++ b/src/models/batch.py
@@ -1,4 +1,5 @@
 
+import re
 from sqlalchemy import Column, String
 
 from database import Base
@@ -26,6 +27,11 @@ class Batch(Base):
         var_map = map(lambda v: '='.join([v.key, v.value]), var_models)
         var_str = ' && '.join(var_map)
         cmd = self.config_model.command()
+        # replace any instances of the variable in cmd with the lowercase
+        for variable in [var_model.key for var_model in var_models]:
+            matches = re.findall(variable, cmd, re.IGNORECASE)
+            for match in matches:
+                cmd = re.sub(match, variable, cmd)
         if var_str: cmd = ' && '.join([var_str, cmd])
         return cmd
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -51,7 +51,8 @@ class Config():
         return self.data['help']
 
     def args(self):
-        return self.arguments or []
+        if self.arguments: return [a.lower() for a in self.arguments]
+        else: return []
 
     # TODO: Deprecated, avoid usage
     def interactive_only(self):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -51,7 +51,7 @@ class Config():
         return self.data['help']
 
     def args(self):
-        if self.arguments: return [a.lower() for a in self.arguments]
+        if self.arguments: return [str(a).lower() for a in self.arguments]
         else: return []
 
     # TODO: Deprecated, avoid usage


### PR DESCRIPTION
Fixes #179 

generally makes tool arguments more robust

Stops breakages if an argument is just an integer
Stops breakage if argument contains any uppercase characters AND handles these as well as possible. All argument names are treated as lowercase, so input, INPUT and InPuT are one and the same.
This is the best possible outcome as we loose info when out command's callback is called by `click` code; the dict that returns is downcased.
https://github.com/alces-software/adminware/blob/develop/src/appliance_cli/command_generation.py#L136