### PR TITLE
Fix/ssh errors

### DIFF
--- a/src/commands/run.py
+++ b/src/commands/run.py
@@ -148,7 +148,6 @@ Over {}:
             try:
                 await add_tasks()
                 run_print('Waiting for jobs to finish...')
-            except concurrent.futures.CancelledError: pass
             finally: await await_finished()
 
         session = Session()
@@ -162,6 +161,7 @@ Over {}:
                 run_print('Executing: {}'.format(batch.name()))
                 tasks = map(lambda j: j.task(thread_pool = pool), batch.jobs)
                 loop.run_until_complete(start_tasks(tasks))
+        except concurrent.futures.CancelledError: pass
         finally:
             run_print('Cleaning up...')
             pool.shutdown(wait = True)

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -64,12 +64,12 @@ available. Please see documentation for possible causes
             self.thread_pool = thread_pool
             super().__init__(self.run_async())
             self.job = job
-            self.add_job_callback(type(self).close)
+            self.add_done_callback(type(self).close)
             self.add_job_callback(lambda job: job.set_ssh_results())
             self.add_done_callback(type(self).report_results)
 
         def close(self):
-            try: self.connection().close()
+            try: self.job.connection().close()
             except RuntimeError as e: click.echo('''
 Failure while closing connection to {}
 {}

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -69,8 +69,11 @@ available. Please see documentation for possible causes
             self.add_done_callback(type(self).report_results)
 
         def close(self):
-            try: job.connection.close()
-            except: pass
+            try: self.connection().close()
+            except RuntimeError as e: click.echo('''
+Failure while closing connection to {}
+{}
+'''.strip().format(self.node, e))
 
         def finished(self):
             return self._state == 'FINISHED'

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -76,7 +76,7 @@ Failure while closing connection to {}
 '''.strip().format(self.node, e))
 
         def finished(self):
-            return self._state == 'FINISHED'
+            return self._state in ['FINISHED', 'CANCELLED']
 
         def __getattr__(self, attr):
             return getattr(self.job, attr)


### PR DESCRIPTION
Fix various errors with ssh connections

Properly close ssh connections to prevent socket file descriptors stacking up & then preventing further connections being established
Add second state condition for the tasks so the system proceeds when they're `CANCELLED` as well 
Interrupt all jobs being ran when an interrupt is sent